### PR TITLE
feat: 프로젝트구인글생성, 상세보기, 조회수, 지원하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.11.0",
     "bootstrap-icons": "^1.13.1",
     "vue": "^3.5.17",
     "vue-router": "^4.0.13",

--- a/src/components/homeComponents/PartnerSection.vue
+++ b/src/components/homeComponents/PartnerSection.vue
@@ -1,4 +1,4 @@
-<template>
+0<template>
   <section class="partner-section">
     <div class="container">
       <div class="section-header">

--- a/src/components/projectComponents/ProjectCard.vue
+++ b/src/components/projectComponents/ProjectCard.vue
@@ -12,15 +12,20 @@
         </div>
       </div>
       <div class="header-right">
+        <div class="view-count-display">
+          👀 {{ project.viewCount }}
+        </div>
         <button class="favorite-button" @click="toggleFavorite" :class="{ 'favorited': isFavorited }">
-          <i class="bi bi-heart-fill" v-if="isFavorited"></i>
-          <i class="bi bi-heart" v-else></i>
+          <span v-if="isFavorited">❤️</span>
+          <span v-else>🤍</span>
         </button>
       </div>
     </div>
 
     <div class="description-section" v-if="project.description">
-      <p class="project-description">{{ project.description }}</p>
+      <p class="project-description">
+        {{ project.description }}
+      </p>
     </div>
 
     <div class="category-tags-section">
@@ -38,7 +43,7 @@
         </div>
         <div class="info-content">
           <div class="info-label">진행 기간</div>
-          <div class="info-value">{{ project.duration }}</div>
+          <div class="info-value">{{ displayDuration  }}</div>
         </div>
       </div>
 
@@ -58,7 +63,7 @@
         </div>
         <div class="info-content">
           <div class="info-label">지원자</div>
-          <div class="info-value">{{ project.applicants }}</div>
+          <div class="info-value">{{ displayDuration  }}</div>
         </div>
       </div>
 
@@ -99,19 +104,42 @@ export default {
       isFavorited: false
     }
   },
+  computed: {
+    displayDuration() {
+      if (!this.project.startDate || !this.project.endDate) return '-';
+      const start = new Date(this.project.startDate);
+      const end = new Date(this.project.endDate);
+      if (isNaN(start) || isNaN(end)) return '-';
+      const diff = Math.round((end - start) / (1000 * 60 * 60 * 24)) + 1; // 날짜 포함
+      if (diff < 7) return `${diff}일`;
+      if (diff < 30) return `${Math.round(diff / 7)}주`;
+      return `${Math.round(diff / 30)}개월`;
+    }
+  },
+  mounted() {
+    console.log('받은 project props', this.project);
+  },
   methods: {
     toggleFavorite() {
       this.isFavorited = !this.isFavorited
     },
     isUrgent(deadline) {
-      if (deadline && deadline.includes('D-')) {
-        const days = parseInt(deadline.replace('D-', ''))
-        return days <= 7
-      }
-      return false
+      if (!deadline) return false
+      // 날짜가 오늘 기준 7일 이내면 urgent (날짜 문자열 YYYY-MM-DD 지원)
+      const today = new Date();
+      const end = new Date(deadline);
+      const diff = (end - today) / (1000 * 60 * 60 * 24);
+      return diff <= 7 && diff >= 0;
+    },
+    formatDeadline(deadline) {
+      if (!deadline) return '-';
+      // 오늘 기준 D-? 표시
+      const today = new Date();
+      const dday = Math.ceil((new Date(deadline) - today) / (1000 * 60 * 60 * 24));
+      if (dday >= 0) return `D-${dday}`;
+      return '마감';
     },
     goToDetail() {
-      // 실제로 id or projectId로 맞춰서 써야 함!
       this.$router.push({
         name: 'ProjectDetail',
         params: { id: this.project.projectId || this.project.id }
@@ -232,6 +260,15 @@ export default {
   font-size: 16px;
 }
 
+.view-count-display {
+  font-size: 14px;
+  color: #666;
+  margin-right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .favorite-button:hover {
   background: rgba(76, 175, 80, 0.1);
   border-color: #4CAF50;
@@ -261,9 +298,13 @@ export default {
   font-weight: 400;
   line-height: 1.6;
   display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .category-tags-section {

--- a/src/components/projectComponents/ProjectCard.vue
+++ b/src/components/projectComponents/ProjectCard.vue
@@ -53,7 +53,7 @@
         </div>
         <div class="info-content">
           <div class="info-label">모집 인원</div>
-          <div class="info-value">{{ project.teamSize }}</div>
+          <div class="info-value">{{ project.recruitCount ?? 0 }}</div>
         </div>
       </div>
 
@@ -63,7 +63,7 @@
         </div>
         <div class="info-content">
           <div class="info-label">지원자</div>
-          <div class="info-value">{{ displayDuration  }}</div>
+          <div class="info-value">{{ project.appliedCount ?? 0  }}</div>
         </div>
       </div>
 
@@ -79,7 +79,7 @@
     </div>
 
     <div class="bottom-section">
-      <button class="apply-button">
+      <button class="apply-button" @click="onApplyClick">
         <i class="bi bi-send"></i>
         지원하기
       </button>
@@ -99,6 +99,38 @@ export default {
       required: true
     }
   },
+  mounted() {
+    console.log('project props in card:', this.project)
+  },
+  methods: {
+    toggleFavorite() {
+      this.isFavorited = !this.isFavorited
+    },
+    isUrgent(deadline) {
+      if (!deadline) return false
+      const today = new Date();
+      const end = new Date(deadline);
+      const diff = (end - today) / (1000 * 60 * 60 * 24);
+      return diff <= 7 && diff >= 0;
+    },
+    formatDeadline(deadline) {
+      if (!deadline) return '-';
+      const today = new Date();
+      const dday = Math.ceil((new Date(deadline) - today) / (1000 * 60 * 60 * 24));
+      if (dday >= 0) return `D-${dday}`;
+      return '마감';
+    },
+    goToDetail() {
+      this.$router.push({
+        name: 'ProjectDetail',
+        params: { id: this.project.projectId || this.project.id }
+      })
+    },
+    onApplyClick() {
+      // 부모에게 프로젝트 정보 emit!
+      this.$emit('apply', this.project)
+    }
+  },
   data() {
     return {
       isFavorited: false
@@ -110,40 +142,10 @@ export default {
       const start = new Date(this.project.startDate);
       const end = new Date(this.project.endDate);
       if (isNaN(start) || isNaN(end)) return '-';
-      const diff = Math.round((end - start) / (1000 * 60 * 60 * 24)) + 1; // 날짜 포함
+      const diff = Math.round((end - start) / (1000 * 60 * 60 * 24)) + 1;
       if (diff < 7) return `${diff}일`;
       if (diff < 30) return `${Math.round(diff / 7)}주`;
       return `${Math.round(diff / 30)}개월`;
-    }
-  },
-  mounted() {
-    console.log('받은 project props', this.project);
-  },
-  methods: {
-    toggleFavorite() {
-      this.isFavorited = !this.isFavorited
-    },
-    isUrgent(deadline) {
-      if (!deadline) return false
-      // 날짜가 오늘 기준 7일 이내면 urgent (날짜 문자열 YYYY-MM-DD 지원)
-      const today = new Date();
-      const end = new Date(deadline);
-      const diff = (end - today) / (1000 * 60 * 60 * 24);
-      return diff <= 7 && diff >= 0;
-    },
-    formatDeadline(deadline) {
-      if (!deadline) return '-';
-      // 오늘 기준 D-? 표시
-      const today = new Date();
-      const dday = Math.ceil((new Date(deadline) - today) / (1000 * 60 * 60 * 24));
-      if (dday >= 0) return `D-${dday}`;
-      return '마감';
-    },
-    goToDetail() {
-      this.$router.push({
-        name: 'ProjectDetail',
-        params: { id: this.project.projectId || this.project.id }
-      })
     }
   }
 }

--- a/src/components/projectComponents/ProjectCard.vue
+++ b/src/components/projectComponents/ProjectCard.vue
@@ -41,7 +41,7 @@
           <div class="info-value">{{ project.duration }}</div>
         </div>
       </div>
-      
+
       <div class="info-item">
         <div class="info-icon">
           <i class="bi bi-people"></i>
@@ -51,7 +51,7 @@
           <div class="info-value">{{ project.teamSize }}</div>
         </div>
       </div>
-      
+
       <div class="info-item">
         <div class="info-icon">
           <i class="bi bi-person-plus"></i>
@@ -61,7 +61,7 @@
           <div class="info-value">{{ project.applicants }}</div>
         </div>
       </div>
-      
+
       <div class="info-item">
         <div class="info-icon">
           <i class="bi bi-calendar-event"></i>
@@ -78,7 +78,7 @@
         <i class="bi bi-send"></i>
         지원하기
       </button>
-      <button class="detail-button">
+      <button class="detail-button" @click="goToDetail">
         상세보기
       </button>
     </div>
@@ -104,11 +104,18 @@ export default {
       this.isFavorited = !this.isFavorited
     },
     isUrgent(deadline) {
-      if (deadline.includes('D-')) {
+      if (deadline && deadline.includes('D-')) {
         const days = parseInt(deadline.replace('D-', ''))
         return days <= 7
       }
       return false
+    },
+    goToDetail() {
+      // 실제로 id or projectId로 맞춰서 써야 함!
+      this.$router.push({
+        name: 'ProjectDetail',
+        params: { id: this.project.projectId || this.project.id }
+      })
     }
   }
 }

--- a/src/components/projectComponents/ProjectHeader.vue
+++ b/src/components/projectComponents/ProjectHeader.vue
@@ -2,22 +2,23 @@
   <div class="project-header">
     <div class="project-tags">
       <div class="tag-container">
-        <span class="tag status-tag">모집중</span>
-        <span class="tag self-tag">#백엔드</span>
-        <span class="tag self-tag">#프론트엔드</span>
-        <span class="tag self-tag">#디자인</span>
-        <span class="tag self-tag">#풀스택프로젝트</span>
+        <span class="tag status-tag">{{ project.status === 'RECRUITING' ? '모집중' : project.status }}</span>
+        <span
+            v-for="(stack, i) in project.techStacks"
+            :key="i"
+            class="tag self-tag"
+        >#{{ stack.techStackName }}</span>
       </div>
       <div class="registration-date">
-        <span>2025.07.10</span>
+        <span>{{ formatDate(project.startDate) }}</span>
       </div>
     </div>
-    
+
     <div class="project-title">
-      <h1>Spring, Vue 기반 프로젝트 멤버 구합니다</h1>
+      <h1>{{ project.title }}</h1>
     </div>
     <div class="project-sub-title">
-      스터디 하면서 프로젝트 진행할 예정입니다
+      {{ project.description }}
     </div>
 
     <hr style="background: #eee; height:1px; border:0; margin: 40px 0">
@@ -25,59 +26,63 @@
     <div class="tag-title">
       이런 기술을 사용할 예정이에요
     </div>
-    <div class="technology-tags">
-      <span class="tech-label">백엔드</span>
-      <div class="tech-tags">
-        <span class="tech-tag">JAVA</span>
-        <span class="tech-tag">Spring</span>
-        <span class="tech-tag">Oracle</span>
-        <span class="tech-tag">AWS S3</span>
-      </div>
+    <div v-if="project.techStacks && project.techStacks.length" class="technology-tags">
+      <span
+          v-for="(ts, i) in project.techStacks"
+          :key="'ts-'+i"
+          class="tech-tag"
+      >{{ ts.techStackName }}</span>
     </div>
 
-    <div class="technology-tags">
-      <span class="tech-label">프론트엔드</span>
-      <div class="tech-tags">
-        <span class="tech-tag">Vue.js</span>
-        <span class="tech-tag">제안 가능</span>
-      </div>
-    </div>
-
-    <div class="technology-tags">
-      <span class="tech-label">디자인</span>
-      <div class="tech-tags">
-        <span class="tech-tag">Figma</span>
-        <span class="tech-tag">제안 가능</span>
-      </div>
-    </div>
-    
     <div class="project-metadata">
       <div class="metadata-item">
         <div class="metadata-label">기간</div>
         <div class="metadata-value">
-          <span class="number">60</span>
+          <span class="number">{{ calcDuration(project.startDate, project.endDate) }}</span>
           <span class="unit">일</span>
         </div>
       </div>
-      
       <div class="metadata-item">
         <div class="metadata-label">지원자수</div>
         <div class="metadata-value">
-          <span class="number">14</span>
+          <span class="number">{{ project.appliedCount || 0 }}</span>
         </div>
       </div>
-      
       <div class="metadata-item">
         <div class="metadata-label">마감일</div>
         <div class="metadata-value">
-          <span class="deadline">D-15</span>
+          <span class="deadline">{{ calcDeadline(project.recruitDeadline) }}</span>
         </div>
       </div>
     </div>
-    
-    
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    project: { type: Object, required: true }
+  },
+  methods: {
+    formatDate(dateStr) {
+      if (!dateStr) return '';
+      const d = new Date(dateStr);
+      return `${d.getFullYear()}.${String(d.getMonth()+1).padStart(2,'0')}.${String(d.getDate()).padStart(2,'0')}`;
+    },
+    calcDuration(start, end) {
+      if (!start || !end) return '-';
+      const s = new Date(start), e = new Date(end);
+      return Math.max(1, Math.ceil((e-s)/(1000*60*60*24)));
+    },
+    calcDeadline(deadline) {
+      if (!deadline) return '-';
+      const today = new Date(), dday = new Date(deadline);
+      const diff = Math.ceil((dday-today)/(1000*60*60*24));
+      return diff > 0 ? `D-${diff}` : '마감';
+    }
+  }
+}
+</script>
 
 <style scoped>
 .project-header {

--- a/src/components/projectComponents/ProjectWorkContent.vue
+++ b/src/components/projectComponents/ProjectWorkContent.vue
@@ -1,21 +1,28 @@
 <template>
-  <div class="work-content">
-    <div class="content-section">
-      <div class="section-header">
-        <h3>프로젝트 내용</h3>
-      </div>
-      
-      <div class="content-text">
-        <div class="content-block">
-          <div class="block-title">※프로젝트의 진행 방식</div>
-          <div class="block-content">
-            <div class="content-line">- 최초 온/오프라인 미팅(협의 가능)</div>
-          </div>
-        </div>
-      </div>
+  <div class="project-content">
+    <div class="project-description">
+      {{ description }}
+    </div>
+    <div v-if="fileUrl" class="project-file">
+      <img v-if="isImage(fileUrl)" :src="fileUrl" alt="첨부이미지" />
+      <a v-else :href="fileUrl" target="_blank" download>첨부파일 다운로드</a>
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    description: String,
+    fileUrl: String,
+  },
+  methods: {
+    isImage(url) {
+      return /\.(jpg|jpeg|png|gif)$/i.test(url)
+    }
+  }
+}
+</script>
 
 <style scoped>
 .work-content {

--- a/src/composables/useFormValidation.js
+++ b/src/composables/useFormValidation.js
@@ -24,11 +24,13 @@ export function useFormValidation() {
   // Validation rules
   const rules = {
     required: (value) => {
-      if (Array.isArray(value)) return value.length > 0
+      if (Array.isArray(value)) return value.length > 0 ? true : '필수 입력 항목입니다.'
       if (typeof value === 'object' && value !== null) {
-        return Object.values(value).some(v => v && v.toString().trim() !== '')
+        return Object.values(value).some(v => v && v.toString().trim() !== '') ? true : '필수 입력 항목입니다.'
       }
       return value !== null && value !== undefined && value.toString().trim() !== ''
+          ? true
+          : '필수 입력 항목입니다.'
     },
     
     email: (value) => {
@@ -78,40 +80,41 @@ export function useFormValidation() {
   // Validate single field
   const validateField = (fieldName, value, fieldRules) => {
     const fieldErrors = []
-    
+
     for (const rule of fieldRules) {
       let isValid = true
       let errorMessage = ''
-      
+
       if (typeof rule === 'string') {
-        // Simple rule like 'required'
-        isValid = rules[rule](value)
-        errorMessage = errorMessages[rule]
+        const result = rules[rule](value)
+        isValid = result === true
+        errorMessage = typeof result === 'string' ? result : errorMessages[rule]
       } else if (typeof rule === 'object') {
-        // Rule with parameters like { minLength: 5 }
         const [ruleName, param] = Object.entries(rule)[0]
-        isValid = rules[ruleName](param)(value)
-        errorMessage = typeof errorMessages[ruleName] === 'function' 
-          ? errorMessages[ruleName](param)
-          : errorMessages[ruleName]
+        const result = rules[ruleName](param)(value)
+        isValid = result === true
+        errorMessage = typeof result === 'string'
+            ? result
+            : (typeof errorMessages[ruleName] === 'function'
+                ? errorMessages[ruleName](param)
+                : errorMessages[ruleName])
       } else if (typeof rule === 'function') {
-        // Custom validation function
         const result = rule(value)
         isValid = result === true
         errorMessage = typeof result === 'string' ? result : '입력 값이 올바르지 않습니다.'
       }
-      
+
       if (!isValid) {
         fieldErrors.push(errorMessage)
       }
     }
-    
+
     if (fieldErrors.length > 0) {
-      errors[fieldName] = fieldErrors[0] // Show only first error
+      errors[fieldName] = fieldErrors[0]
     } else {
       delete errors[fieldName]
     }
-    
+
     return fieldErrors.length === 0
   }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -37,7 +37,7 @@ const routes = [
   },
   {
     // 프로젝트 상세
-    path: '/project/:id',
+    path: '/projects/:id',
     name: 'ProjectDetail',
     component: ProjectDetailPage,
   },

--- a/src/views/ProjectCreatePage.vue
+++ b/src/views/ProjectCreatePage.vue
@@ -44,16 +44,23 @@
               {{ getError('projectTitle').value }}
             </div>
           </div>
-          <div class="input-group">
-            <input
-              type="text"
-              v-model="formData.projectSubtitle"
-              :class="['project-subtitle-input', { 'error': getError('projectSubtitle').value }]"
-              placeholder="프로젝트의 간략한 소개말을 입력해주세요."
-              @blur="validateField('projectSubtitle', formData.projectSubtitle, validationSchema.projectSubtitle)"
-            />
-            <div v-if="getError('projectSubtitle').value" class="error-message">
-              {{ getError('projectSubtitle').value }}
+        </div>
+
+        <div class="form-section">
+
+          <div class="section-title">프로젝트 내용</div>
+          <div class="form-inputs">
+            <div class="input-group">
+              <textarea
+                  v-model="formData.projectDescription"
+                  :class="['project-description-textarea', { 'error': getError('projectDescription').value }]"
+                  placeholder="프로젝트에 대한 정보를 입력해주세요."
+                  rows="6"
+                  @blur="validateField('projectDescription', formData.projectDescription, validationSchema.projectDescription)"
+              ></textarea>
+              <div v-if="getError('projectDescription').value" class="error-message">
+                {{ getError('projectDescription').value }}
+              </div>
             </div>
           </div>
         </div>
@@ -101,6 +108,7 @@
             </div>
           </div>
         </div>
+
         <div class="form-section">
           <div class="section-title">기술 스택</div>
           <p class="upload-note">입력된 기술 스택은 프로젝트 추천 서비스에 이용됩니다.</p>
@@ -114,21 +122,17 @@
           </div>
         </div>
 
-        <div class="form-section">
-
-          <div class="section-title">프로젝트 내용</div>
-          <div class="form-inputs">
-            <div class="input-group">
-              <textarea
-                v-model="formData.projectDescription"
-                :class="['project-description-textarea', { 'error': getError('projectDescription').value }]"
-                placeholder="프로젝트에 대한 정보를 입력해주세요."
-                rows="6"
-                @blur="validateField('projectDescription', formData.projectDescription, validationSchema.projectDescription)"
-              ></textarea>
-              <div v-if="getError('projectDescription').value" class="error-message">
-                {{ getError('projectDescription').value }}
-              </div>
+        <div class="form-section deadline-section">
+          <div class="section-title">모집 마감일</div>
+          <div class="input-group">
+            <input
+                type="date"
+                v-model="formData.recruitDeadline"
+                :min="new Date().toISOString().slice(0, 10)"
+                :class="['deadline-input', { 'error': getError('recruitDeadline').value }]"
+            />
+            <div v-if="getError('recruitDeadline').value" class="error-message">
+              {{ getError('recruitDeadline').value }}
             </div>
           </div>
         </div>
@@ -212,7 +216,9 @@ export default {
       personnel: 1,
       techStack: [],
       projectDescription: '',
-      files: []
+      files: [],
+      recruitDeadline: '',
+      viewCount: 0
     })
 
     const validationSchema = {
@@ -235,6 +241,16 @@ export default {
         'required',
         (value) => {
           if (!value) return '진행 기간 단위를 선택해주세요.'
+          return true
+        }
+      ],
+      recruitDeadline: [
+        'required',
+        (value) => {
+          if (!value) return '모집 마감일을 선택해주세요.'
+          // 오늘 날짜보다 이전일 수 없음
+          const today = new Date().toISOString().slice(0, 10)
+          if (value < today) return '오늘 이후의 날짜를 선택하세요.'
           return true
         }
       ],
@@ -321,7 +337,7 @@ export default {
         const body = {
           title: formData.projectTitle,
           description: formData.projectDescription,
-          recruitDeadline: endDate,
+          recruitDeadline: formData.recruitDeadline,
           startDate: startDate,
           endDate: endDate,
           fileUrl: fileUrl,
@@ -563,6 +579,28 @@ export default {
 
 .personnel-error {
   align-self: flex-end; /* 에러 메시지도 오른쪽 정렬 */
+}
+
+.deadline-section {
+  margin-bottom: 80px; /* 다른 섹션과 동일하게 */
+}
+.deadline-input {
+  width: 230px;
+  padding: 16px;
+  border-radius: 8px;
+  border: 2px solid var(--color-grey-85, #D9D9D9);
+  background: #FFF;
+  font-size: 15px;
+  color: #262626;
+  transition: all 0.2s;
+}
+.deadline-input:focus {
+  border-color: #4CAF50;
+  box-shadow: 0 0 0 3px rgba(76,175,80,0.08);
+}
+.deadline-input.error {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 3px rgba(220,53,69,0.1);
 }
 
 .form-inputs {

--- a/src/views/ProjectCreatePage.vue
+++ b/src/views/ProjectCreatePage.vue
@@ -171,16 +171,19 @@
 </template>
 
 <script>
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed } from 'vue'
+import axios from 'axios'
 import PersonnelCounter from '@/components/projectComponents/PersonnelCounter.vue'
 import TechStackSelector from '@/components/projectComponents/TechStackSelector.vue'
 import FileUploadArea from '@/components/projectComponents/FileUploadArea.vue'
 import { useFormValidation } from '@/composables/useFormValidation.js'
+import {useRouter} from "vue-router";
+
+const API_URL = 'http://localhost:8080/api/projects'
 
 export default {
   name: 'ProjectCreatePage',
   components: {
-    // DateRangeInput, // 제거
     PersonnelCounter,
     TechStackSelector,
     FileUploadArea
@@ -198,29 +201,30 @@ export default {
       getError
     } = useFormValidation()
 
+    const router = useRouter()
     const showSuccess = ref(false)
 
     const formData = reactive({
-      projectTitle: '', 
-      projectSubtitle: '', 
-      projectDurationValue: null, 
-      projectDurationUnit: '',    
-      personnel: 1, 
+      projectTitle: '',
+      projectSubtitle: '',
+      projectDurationValue: null,
+      projectDurationUnit: '',
+      personnel: 1,
       techStack: [],
       projectDescription: '',
       files: []
     })
 
     const validationSchema = {
-      projectTitle: [ 
+      projectTitle: [
         'required',
         { minLength: 5, message: '프로젝트 제목은 최소 5자 이상이어야 합니다.' },
         { maxLength: 100, message: '프로젝트 제목은 최대 100자까지 가능합니다.' }
       ],
-      projectSubtitle: [ 
+      projectSubtitle: [
         { maxLength: 200, message: '소제목은 최대 200자까지 가능합니다.' }
       ],
-      projectDurationValue: [ // 진행 기간 숫자 값 유효성 검사 추가
+      projectDurationValue: [
         'required',
         (value) => {
           if (value === null || value === '' || isNaN(value) || value < 0) return '올바른 진행 기간 숫자를 입력해주세요.'
@@ -267,25 +271,74 @@ export default {
       ]
     }
 
-    const submitForm = async () => {
-      validateField('projectDurationValue', formData.projectDurationValue, validationSchema.projectDurationValue);
-      validateField('projectDurationUnit', formData.projectDurationUnit, validationSchema.projectDurationUnit);
+    // 날짜 유틸
+    function addDurationToDate(start, value, unit) {
+      const date = new Date(start)
+      if (unit === 'days') date.setDate(date.getDate() + value)
+      if (unit === 'weeks') date.setDate(date.getDate() + value * 7)
+      if (unit === 'months') date.setMonth(date.getMonth() + value)
+      if (unit === 'years') date.setFullYear(date.getFullYear() + value)
+      return date.toISOString().slice(0, 10)
+    }
 
+    //구인글 등록 submitForm 실제 동작 코드
+    const submitForm = async () => {
+      validateField('projectDurationValue', formData.projectDurationValue, validationSchema.projectDurationValue)
+      validateField('projectDurationUnit', formData.projectDurationUnit, validationSchema.projectDurationUnit)
+      submitAttempted.value = true
 
       if (!validateForm(formData, validationSchema)) {
+        isSubmitting.value = false
         return
       }
 
       isSubmitting.value = true
 
       try {
-        await new Promise(resolve => setTimeout(resolve, 2000))
+        // 1. 파일 업로드(S3)
+        let fileUrl = null
+        if (formData.files && formData.files.length > 0) {
+          const uploadData = new FormData()
+          uploadData.append('file', formData.files[0])
+          const uploadRes = await axios.post(`${API_URL}/upload-file`, uploadData, {
+            headers: { 'Content-Type': 'multipart/form-data' }
+          })
+          fileUrl = uploadRes.data // S3 URL
+        }
+
+        // 2. 날짜 계산 (시작일: 오늘, 마감일: 오늘+기간)
+        const today = new Date()
+        const startDate = today.toISOString().slice(0, 10)
+        const endDate = addDurationToDate(today, formData.projectDurationValue, formData.projectDurationUnit)
+
+        // 3. techStacks DTO 변환
+        const techStacks = formData.techStack.map(ts => ({
+          techStackName: ts.techStackName || ts.name, // 실제 구조에 맞게
+          recruitCount: ts.recruitCount || 1 // 기본값 1
+        }))
+
+        // 4. 등록 DTO 맞춰서 body 생성
+        const body = {
+          title: formData.projectTitle,
+          description: formData.projectDescription,
+          recruitDeadline: endDate,
+          startDate: startDate,
+          endDate: endDate,
+          fileUrl: fileUrl,
+          status: 'RECRUITING',
+          techStacks: techStacks,
+          recruitCount: formData.personnel
+        }
+
+        // 5. 실제 구인글 등록 요청 (userId=1는 임시)
+        await axios.post(`${API_URL}?userId=1`, body, {
+          headers: { 'Content-Type': 'application/json' }
+        })
 
         showSuccess.value = true
         clearErrors()
-
-        console.log('Form submitted successfully:', formData)
-
+        router.push('/projects')
+        // 필요시 resetForm()
       } catch (error) {
         console.error('Submission error:', error)
         alert('등록 중 오류가 발생했습니다. 다시 시도해주세요.')
@@ -305,7 +358,6 @@ export default {
         projectDescription: '',
         files: []
       })
-
       clearErrors()
       showSuccess.value = false
     }

--- a/src/views/ProjectDetailPage.vue
+++ b/src/views/ProjectDetailPage.vue
@@ -6,38 +6,22 @@
       <div class="shape shape-2"></div>
       <div class="shape shape-3"></div>
     </div>
-
     <div class="page-container">
       <div class="content-wrapper">
         <div class="main-content">
           <div class="header-section">
-            <ProjectHeader />
+            <ProjectHeader :project="project" />
           </div>
-
           <div class="integrated-content-card">
             <div class="tab-section">
-              <TabNavigation
-                :activeTab="activeTab"
-                @tab-change="handleTabChange"
-              />
+              <TabNavigation :activeTab="activeTab" @tab-change="handleTabChange" />
             </div>
-
             <div class="tab-content">
-              <ProjectWorkContent id="content-section" />
-              <ProjectComment id="comment-section" />
+              <ProjectWorkContent :description="project.description" :file-url="project.fileUrl" />
+              <ProjectComment :projectId="project.projectId" id="comment-section" />
             </div>
           </div>
         </div>
-  <div class="main-content">
-    <div class="project-content">
-      <!-- props로 project 내려줌 -->
-      <ProjectHeader :project="project" />
-      <div class="tab-section">
-        <TabNavigation :activeTab="activeTab" @tab-change="handleTabChange" />
-      </div>
-      <div class="tab-content">
-        <ProjectWorkContent :description="project.description" :file-url="project.fileUrl" />
-        <ProjectComment :projectId="project.projectId" id="comment-section" />
       </div>
     </div>
   </div>

--- a/src/views/ProjectDetailPage.vue
+++ b/src/views/ProjectDetailPage.vue
@@ -1,24 +1,21 @@
 <template>
   <div class="main-content">
     <div class="project-content">
-      <ProjectHeader />
-      
+      <!-- props로 project 내려줌 -->
+      <ProjectHeader :project="project" />
       <div class="tab-section">
-        <TabNavigation 
-          :activeTab="activeTab" 
-          @tab-change="handleTabChange" 
-        />
+        <TabNavigation :activeTab="activeTab" @tab-change="handleTabChange" />
       </div>
-      
       <div class="tab-content">
-        <ProjectWorkContent id="content-section" />
-        <ProjectComment id="comment-section" />
+        <ProjectWorkContent :description="project.description" :file-url="project.fileUrl" />
+        <ProjectComment :projectId="project.projectId" id="comment-section" />
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import axios from 'axios'
 import TabNavigation from '@/components/projectComponents/TabNavigation.vue'
 import ProjectHeader from '@/components/projectComponents/ProjectHeader.vue'
 import ProjectWorkContent from '@/components/projectComponents/ProjectWorkContent.vue'
@@ -34,31 +31,30 @@ export default {
   },
   data() {
     return {
+      project: {},
       activeTab: 'content'
+    }
+  },
+  async created() {
+    const id = this.$route.params.id
+    try {
+      const res = await axios.get(`http://localhost:8080/api/projects/${id}`)
+      this.project = res.data
+    } catch (e) {
+      alert('프로젝트 정보를 불러오지 못했습니다.')
+      console.error(e)
     }
   },
   methods: {
     handleTabChange(tab) {
-      this.activeTab = tab; // 현재 활성 탭 상태 업데이트 (시각적 표시용)
-      
-      let targetId = '';
-      if (tab === 'content') {
-        targetId = 'content-section';
-      } else if (tab === 'comment') {
-        targetId = 'comment-section';
-      }
-
+      this.activeTab = tab
+      let targetId = (tab === 'content') ? 'content-section'
+          : (tab === 'comment') ? 'comment-section' : ''
       if (targetId) {
-        // 다음 틱에 DOM이 업데이트된 후 스크롤을 실행하기 위해 nextTick 사용
         this.$nextTick(() => {
-          const element = document.getElementById(targetId);
-          if (element) {
-            element.scrollIntoView({ 
-              behavior: 'smooth', // 부드러운 스크롤 효과
-              block: 'start'     // 요소의 상단이 뷰포트 상단에 오도록
-            });
-          }
-        });
+          const element = document.getElementById(targetId)
+          if (element) element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        })
       }
     }
   }

--- a/src/views/ProjectDetailPage.vue
+++ b/src/views/ProjectDetailPage.vue
@@ -10,7 +10,6 @@
       <div class="content-wrapper">
         <div class="main-content">
           <div class="header-section">
-            <ProjectHeader />
             <!-- 지원하기 버튼 추가 -->
             <div class="apply-button-container">
               <button
@@ -61,8 +60,8 @@
                 <span class="project-icon">📋</span>
                 <h3 class="project-info-title">지원 프로젝트</h3>
               </div>
-              <div class="project-name">{{ projectInfo.name }}</div>
-              <div class="project-description">{{ projectInfo.description }}</div>
+              <div class="project-name">{{ project.title }}</div>
+              <div class="project-description">{{ project.description }}</div>
             </div>
           </div>
 
@@ -194,7 +193,6 @@ export default {
     return {
       project: {},
       activeTab: 'content',
-      activeTab: 'content',
       showApplyModal: false,
       showSuccessToast: false,
       isSubmitting: false,
@@ -234,20 +232,11 @@ export default {
   methods: {
     handleTabChange(tab) {
       this.activeTab = tab
-      let targetId = (tab === 'content') ? 'content-section'
-          : (tab === 'comment') ? 'comment-section' : ''
-      if (targetId) {
-        this.$nextTick(() => {
-          const element = document.getElementById(targetId)
-          if (element) element.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        })
-      }
 
       const sectionMap = {
         content: 'content-section',
         comment: 'comment-section'
       }
-
       const targetId = sectionMap[tab]
       if (!targetId) return
 
@@ -284,23 +273,24 @@ export default {
       this.isSubmitting = true
 
       try {
-        // 실제 API 호출 로직을 여기에 구현
-        await new Promise(resolve => setTimeout(resolve, 1500)) // 시뮬레이션
+        // 실제 API 호출 (프로젝트 지원)
+        await axios.post(
+            `http://localhost:8080/api/projects/${this.project.projectId}/apply`,
+            {
+              userId: 5, // 실제 로그인 유저 ID로 바꾸세요
+              applicationMessage: this.applicationForm.message,
+              techStack: this.applicationForm.part
+            }
+        )
 
-        console.log('지원 정보:', {
-          project: this.projectInfo.name,
-          ...this.applicationForm,
-          portfolioPublic: this.userPortfolio.isPublic
-        })
-
-        this.closeApplyModal()
         this.showSuccessToast = true
 
-        // 3초 후 토스트 메시지 숨기기
+        // 3초 후 토스트 메시지 숨김
         setTimeout(() => {
           this.showSuccessToast = false
         }, 3000)
 
+        this.closeApplyModal()
       } catch (error) {
         console.error('지원 실패:', error)
         alert('지원 중 오류가 발생했습니다. 다시 시도해주세요.')
@@ -458,23 +448,24 @@ export default {
 
 /* 지원하기 버튼 스타일 */
 .apply-button-container {
-  margin-top: 30px;
+  margin-bottom: 20px;
   display: flex;
   justify-content: center;
+  padding-right: 10px;
 }
 
 .apply-button {
   background: linear-gradient(135deg, #4CAF50, #66BB6A);
   color: white;
   border: none;
-  padding: 16px 32px;
+  padding: 12px 28px;
   border-radius: 50px;
-  font-size: 16px;
+  font-size: 14.5px;
   font-weight: 600;
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   transition: all 0.3s ease;
   box-shadow: 0 8px 25px rgba(76, 175, 80, 0.3);
 }
@@ -490,7 +481,7 @@ export default {
 }
 
 .apply-icon {
-  font-size: 18px;
+  font-size: 16px;
 }
 
 /* 모달 스타일 */
@@ -867,8 +858,9 @@ export default {
 /* 성공 토스트 */
 .success-toast {
   position: fixed;
-  top: 30px;
-  right: 30px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: linear-gradient(135deg, #4CAF50, #66BB6A);
   color: white;
   padding: 16px 24px;

--- a/src/views/ProjectListPage.vue
+++ b/src/views/ProjectListPage.vue
@@ -96,14 +96,25 @@ export default {
       projects: []   // 백에서 받아올거라 빈 배열로 초기화
     }
   },
+  mounted() {
+    console.log('받은 project:', this.project)
+  },
   created() {
     this.fetchProjects();
+  },
+  watch: {
+    '$route'(to, from) {
+      if (from.name === 'ProjectDetail') {
+        this.fetchProjects();  //상세 페이지에서 돌아올 때 조회수 포함 새로고침
+      }
+    }
   },
   methods: {
     // 프로젝트 리스트 API 호출
     async fetchProjects() {
       try {
         const response = await axios.get('http://localhost:8080/api/projects'); // 실제 API 주소로 수정!
+        console.log('API 응답', response.data);
         // API 응답을 projects에 저장
         this.projects = response.data.map(project => ({
           id: project.projectId,
@@ -113,6 +124,9 @@ export default {
           status: project.status === 'RECRUITING' ? '모집중' : project.status,
           teamSize: project.recruitCount + '명',     // 인원 표시
           applicants: project.appliedCount + '명',   // 지원자 수
+          startDate: project.startDate,
+          endDate: project.endDate,
+          viewCount: project.viewCount ?? 0,
           deadline: project.recruitDeadline ? this.calcDeadline(project.recruitDeadline) : '', // 디데이 계산
         }))
       } catch (error) {

--- a/src/views/ProjectListPage.vue
+++ b/src/views/ProjectListPage.vue
@@ -77,6 +77,7 @@
 </template>
 
 <script>
+import axios from 'axios'
 import SearchSection from '@/components/projectComponents/SearchSection.vue'
 import SortOptions from '@/components/projectComponents/SortOptions.vue'
 import ProjectCard from '@/components/projectComponents/ProjectCard.vue'
@@ -92,46 +93,42 @@ export default {
   },
   data() {
     return {
-      projects: [
-        {
-          id: 1,
-          title: 'JAVA Spring, Vue 기반 프로젝트',
-          description: '스터디 하면서 프로젝트 진행할 분들 구합니다',
-          tags: ['JAVA', 'Spring', 'Vue', '웹개발'],
-          status: '모집중',
-          duration: '3개월',
-          teamSize: '3명',
-          applicants: '0명',
-          deadline: 'D-16',
-        },
-        {
-          id: 2,
-          title: 'Lock Screen 앱 5종 AOS 최신화 및 마켓 등록',
-          description: '',
-          tags: ['Android', '모바일', '어플'],
-          status: '모집중',
-          duration: '3개월',
-          teamSize: '6명',
-          applicants: '2명',
-          deadline: 'D-13',
-        },
-        {
-          id: 3,
-          title: 'Web 프레임워크 및 UI 시스템 고도화',
-          description: '',
-          tags: ['React', 'TypeScript', 'vite', 'StoryBook', 'CSS-in-JS'],
-          status: '모집중',
-          duration: '6개월',
-          teamSize: '3명',
-          applicants: '0명',
-          deadline: 'D-16',
-        }
-      ]
+      projects: []   // 백에서 받아올거라 빈 배열로 초기화
     }
   },
+  created() {
+    this.fetchProjects();
+  },
   methods: {
+    // 프로젝트 리스트 API 호출
+    async fetchProjects() {
+      try {
+        const response = await axios.get('http://localhost:8080/api/projects'); // 실제 API 주소로 수정!
+        // API 응답을 projects에 저장
+        this.projects = response.data.map(project => ({
+          id: project.projectId,
+          title: project.title,
+          description: project.description,
+          tags: project.techStacks,   // (tags 대신 techStacks 필드 사용)
+          status: project.status === 'RECRUITING' ? '모집중' : project.status,
+          teamSize: project.recruitCount + '명',     // 인원 표시
+          applicants: project.appliedCount + '명',   // 지원자 수
+          deadline: project.recruitDeadline ? this.calcDeadline(project.recruitDeadline) : '', // 디데이 계산
+        }))
+      } catch (error) {
+        alert('프로젝트 목록을 불러오는데 실패했습니다.');
+        console.error(error);
+      }
+    },
+    calcDeadline(recruitDeadline) {
+      // D-day 계산 (오늘 기준 마감일까지 며칠 남았는지)
+      const today = new Date();
+      const deadline = new Date(recruitDeadline);
+      const diff = Math.ceil((deadline - today) / (1000 * 60 * 60 * 24));
+      return diff > 0 ? `D-${diff}` : '마감';
+    },
     goToCreateProject() {
-      this.$router.push({ name: 'CreateProject' }); 
+      this.$router.push({ name: 'ProjectCreate' }); // 라우터 이름 정확히 맞춰서!
     }
   }
 }

--- a/src/views/ProjectListPage.vue
+++ b/src/views/ProjectListPage.vue
@@ -66,7 +66,7 @@
                 v-for="project in filteredProjects"
                 :key="project.id"
                 :project="project"
-                @application-submitted="handleApplicationSubmitted"
+                @apply="openApplyModal"
               />
             </div>
           </div>
@@ -74,6 +74,26 @@
         </div>
       </div>
     </div>
+    <ApplyModal
+        v-if="showApplyModal"
+        :visible="showApplyModal"
+        :project-info="selectedProject"
+        :user-portfolio="userPortfolio"
+        @close="closeApplyModal"
+        @submit="handleApplicationSubmitted"
+        @portfolio-settings="goToPortfolioSettings"
+    />
+  </div>
+  <div
+      v-if="showSuccessToast"
+      class="success-toast"
+  >
+    <span class="toast-icon">✅</span>
+    지원이 성공적으로 완료되었습니다!
+  </div>
+  <div v-if="showFailToast" class="fail-toast">
+    <span class="toast-icon">❌</span>
+    지원에 실패했습니다. 다시 시도해주세요.
   </div>
 </template>
 
@@ -83,6 +103,7 @@ import SearchSection from '@/components/projectComponents/SearchSection.vue'
 import SortOptions from '@/components/projectComponents/SortOptions.vue'
 import ProjectCard from '@/components/projectComponents/ProjectCard.vue'
 import PaginationComponent from '@/components/projectComponents/PaginationComponent.vue'
+import ApplyModal from '@/components/projectComponents/ApplyModal.vue'
 
 export default {
   name: 'ProjectListPage',
@@ -90,45 +111,53 @@ export default {
     SearchSection,
     SortOptions,
     ProjectCard,
-    PaginationComponent
+    PaginationComponent,
+    ApplyModal
   },
   data() {
     return {
-      projects: []   // 백에서 받아올거라 빈 배열로 초기화
+      projects: [],
+      selectedCategory: null,
+      showApplyModal: false,
+      showSuccessToast: false,
+      showFailToast: false, // 모달 ON/OFF
+      selectedProject: null,         // 모달에 넘길 프로젝트 데이터
+      userPortfolio: {               // 예시. 실제론 유저 데이터 연동!
+        isPublic: true,
+        lastUpdated: '2024-07-29'
+      }
     }
-  },
-  mounted() {
-    console.log('받은 project:', this.project)
   },
   created() {
     this.fetchProjects();
   },
-  watch: {
-    '$route'(to, from) {
-      if (from.name === 'ProjectDetail') {
-        this.fetchProjects();  //상세 페이지에서 돌아올 때 조회수 포함 새로고침
-      }
+  computed: {
+    filteredProjects() {
+      // 카테고리 필터도 실제 적용시 아래처럼 조건 추가
+      // if (this.selectedCategory) { ... }
+      return this.projects;
     }
   },
   methods: {
     // 프로젝트 리스트 API 호출
     async fetchProjects() {
       try {
-        const response = await axios.get('http://localhost:8080/api/projects'); // 실제 API 주소로 수정!
-        console.log('API 응답', response.data);
-        // API 응답을 projects에 저장
-        this.projects = response.data.map(project => ({
+        const response = await axios.get('http://localhost:8080/api/projects');
+        this.projects = response.data
+            .slice() // 데이터 복제
+            .sort((a, b) => new Date(a.recruitDeadline) - new Date(b.recruitDeadline))
+            .map(project => ({
           id: project.projectId,
           title: project.title,
           description: project.description,
-          tags: project.techStacks,   // (tags 대신 techStacks 필드 사용)
+          tags: project.techStacks,
           status: project.status === 'RECRUITING' ? '모집중' : project.status,
-          teamSize: project.recruitCount + '명',     // 인원 표시
-          applicants: project.appliedCount + '명',   // 지원자 수
+          recruitCount: project.recruitCount,
+          appliedCount: project.appliedCount,
           startDate: project.startDate,
           endDate: project.endDate,
           viewCount: project.viewCount ?? 0,
-          deadline: project.recruitDeadline ? this.calcDeadline(project.recruitDeadline) : '', // 디데이 계산
+          deadline: project.recruitDeadline ? this.calcDeadline(project.recruitDeadline) : '',
         }))
       } catch (error) {
         alert('프로젝트 목록을 불러오는데 실패했습니다.');
@@ -136,38 +165,118 @@ export default {
       }
     },
     calcDeadline(recruitDeadline) {
-      // D-day 계산 (오늘 기준 마감일까지 며칠 남았는지)
       const today = new Date();
       const deadline = new Date(recruitDeadline);
       const diff = Math.ceil((deadline - today) / (1000 * 60 * 60 * 24));
       return diff > 0 ? `D-${diff}` : '마감';
     },
     goToCreateProject() {
-      this.$router.push({ name: 'CreateProject' })
+      this.$router.push({name: 'ProjectCreate'})
     },
-
     filterByCategory(category) {
       this.selectedCategory = this.selectedCategory === category ? null : category
     },
-
-    handleApplicationSubmitted(data) {
-      console.log('지원 완료:', data)
-
-      // 프로젝트의 지원자 수 업데이트
-      const project = this.projects.find(p => p.id === data.projectId)
-      if (project) {
-        const currentApplicants = parseInt(project.applicants.replace('명', ''))
-        project.applicants = `${currentApplicants + 1}명`
+    openApplyModal(project) {
+      if (!project) return
+      this.selectedProject = {
+        title: project.title,
+        description: project.description,
+        projectId: project.id
       }
+      this.showApplyModal = true
+    },
+    closeApplyModal() {
+      this.showApplyModal = false
+      this.selectedProject = null
+    },
+    goToPortfolioSettings() {
+      this.closeApplyModal()
+      this.$router.push({name: 'PortfolioSettings'})
+    },
+    async handleApplicationSubmitted(data) {
+      if (!data || !data.applicationForm) return
 
-      // 서버에 지원 정보 전송 (실제 구현 시)
-      // this.submitApplicationToServer(data)
+      const message = data.applicationForm.message || ''
+      const part = data.applicationForm.part || ''
+
+      try {
+        await axios.post(
+            `http://localhost:8080/api/projects/${this.selectedProject.projectId}/apply`,
+            {
+              userId: 3,
+              applicationMessage: message,
+              techStack: part
+            }
+        )
+        this.showSuccessToast = true
+        setTimeout(() => {
+          this.showSuccessToast = false
+        }, 3000)
+        this.closeApplyModal()
+      } catch (e) {
+        if (e.response && e.response.status === 409) {
+          this.showFailToast = true
+        } else {
+          this.showFailToast = true
+          console.error(e)
+        }
+        setTimeout(() => {
+          this.showFailToast = false
+        }, 3000)
+        this.closeApplyModal()
+      }
     }
   }
 }
 </script>
 
 <style scoped>
+.success-toast {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(135deg, #4CAF50, #66BB6A);
+  color: white;
+  padding: 16px 24px;
+  border-radius: 12px;
+  box-shadow: 0 8px 25px rgba(76, 175, 80, 0.3);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  z-index: 1001;
+  animation: slideInRight 0.3s ease;
+}
+.fail-toast {
+  position: fixed;
+  top: 80px;
+  right: 30px;
+  background: linear-gradient(135deg, #f44336, #e57373);
+  color: white;
+  padding: 16px 24px;
+  border-radius: 12px;
+  box-shadow: 0 8px 25px rgba(244, 67, 54, 0.3);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  z-index: 1001;
+  animation: slideInRight 0.3s ease;
+}
+.toast-icon {
+  font-size: 18px;
+}
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(100px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
 .project-list-page {
   min-height: 100vh;
   background: #FFF;


### PR DESCRIPTION
feat/프로젝트구인글생성, 상세보기, 조회수, 지원하기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 프로젝트 목록, 상세, 카드, 헤더, 내용 등에서 실제 API 연동으로 동적 데이터 표시 및 지원 기능 추가
  * 프로젝트 지원 시 모달 창 및 토스트 알림 제공
  * 프로젝트 생성 시 모집 마감일 입력 및 유효성 검사 추가, 파일 업로드 및 DTO 변환 지원

* **기능 개선**
  * 프로젝트 카드에 조회수, 이모지 아이콘, 지원/상세보기 버튼 등 UI 개선
  * 프로젝트 헤더·내용·리스트 등에서 데이터 표시 및 계산 로직 동적 처리
  * 지원자 수, 모집 인원 등 기본값 처리 및 날짜 계산 로직 개선

* **버그 수정**
  * 프로젝트 상세, 리스트, 카드 등에서 잘못된 경로 및 데이터 처리 오류 수정

* **스타일**
  * 프로젝트 카드, 지원 모달, 토스트 알림 등 UI/UX 스타일 개선

* **리팩터링**
  * 하드코딩된 데이터 제거, 컴포넌트 간 데이터 전달 방식 통일

* **기타**
  * 라우터 경로 `/project/:id` → `/projects/:id`로 변경
  * 폼 유효성 검사 메시지 및 로직 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->