### PR TITLE
refactor: profile img

### DIFF
--- a/src/components/common/PaginationComponent.vue
+++ b/src/components/common/PaginationComponent.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="pagination-bar" v-if="totalPages > 1">
+    <!-- 이전 페이지 -->
+    <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">이전</button>
+    
+    <!-- 이전 그룹 -->
+    <button v-if="hasPrevGroup" @click="goToPrevGroup" class="group-nav">...</button>
+    
+    <!-- 현재 그룹의 페이지들 -->
+    <button
+      v-for="p in visiblePages"
+      :key="p"
+      :class="{ active: currentPage === p }"
+      @click="goToPage(p)"
+    >
+      {{ p }}
+    </button>
+    
+    <!-- 다음 그룹 -->
+    <button v-if="hasNextGroup" @click="goToNextGroup" class="group-nav">...</button>
+    
+    <!-- 다음 페이지 -->
+    <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">다음</button>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  currentPage: {
+    type: Number,
+    required: true,
+    default: 1
+  },
+  totalPages: {
+    type: Number,
+    required: true,
+    default: 1
+  },
+  pageGroupSize: {
+    type: Number,
+    default: 5
+  }
+});
+
+const emit = defineEmits(['page-change']);
+
+const goToPage = (page) => {
+  if (page >= 1 && page <= props.totalPages && page !== props.currentPage) {
+    emit('page-change', page);
+  }
+};
+
+// 그룹 페이징 로직
+const currentPageGroup = computed(() => {
+  return Math.ceil(props.currentPage / props.pageGroupSize);
+});
+
+const pageGroupStart = computed(() => {
+  return (currentPageGroup.value - 1) * props.pageGroupSize + 1;
+});
+
+const pageGroupEnd = computed(() => {
+  return Math.min(currentPageGroup.value * props.pageGroupSize, props.totalPages);
+});
+
+const visiblePages = computed(() => {
+  const pages = [];
+  for (let i = pageGroupStart.value; i <= pageGroupEnd.value; i++) {
+    pages.push(i);
+  }
+  return pages;
+});
+
+const hasPrevGroup = computed(() => {
+  return currentPageGroup.value > 1;
+});
+
+const hasNextGroup = computed(() => {
+  return currentPageGroup.value < Math.ceil(props.totalPages / props.pageGroupSize);
+});
+
+const goToPrevGroup = () => {
+  const prevGroupLastPage = (currentPageGroup.value - 1) * props.pageGroupSize;
+  goToPage(prevGroupLastPage);
+};
+
+const goToNextGroup = () => {
+  const nextGroupFirstPage = currentPageGroup.value * props.pageGroupSize + 1;
+  goToPage(nextGroupFirstPage);
+};
+</script>
+
+<style scoped>
+.pagination-bar {
+  margin-top: 24px;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+
+.pagination-bar button {
+  background: #fff;
+  border: 1px solid #D1D5DB;
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: 500;
+  min-width: 40px;
+}
+
+.pagination-bar button:hover {
+  background: #F1F8E9;
+  border-color: #C8E6C9;
+  color: #2E7D32;
+}
+
+.pagination-bar button.active {
+  background: #4CAF50;
+  color: #fff;
+  border-color: #4CAF50;
+}
+
+.pagination-bar button:disabled { 
+  opacity: 0.5; 
+  cursor: default; 
+  background: #F3F4F6; 
+}
+
+.pagination-bar button:disabled:hover {
+  background: #F3F4F6;
+  border-color: #D1D5DB;
+  color: inherit;
+}
+
+.pagination-bar button.group-nav {
+  background: #F9FAFB;
+  border-color: #E5E7EB;
+  color: #6B7280;
+  font-weight: 600;
+}
+
+.pagination-bar button.group-nav:hover {
+  background: #E5E7EB;
+  border-color: #D1D5DB;
+  color: #4B5563;
+}
+</style>

--- a/src/components/common/ProfileImage.vue
+++ b/src/components/common/ProfileImage.vue
@@ -1,0 +1,226 @@
+<template>
+  <div class="profile-image-container" :class="sizeClass">
+    <img
+      :src="currentSrc"
+      :alt="alt"
+      :class="['profile-image', { circular, rounded }]"
+      @error="handleImageError"
+      @load="handleImageLoad"
+    />
+    <div v-if="showStatus && status" :class="['status-indicator', status]"></div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  // 이미지 소스 (백엔드의 profileImage 또는 다른 이미지 URL)
+  src: {
+    type: String,
+    default: null
+  },
+  // 사용자 ID (fallback 이미지 생성용)
+  userId: {
+    type: [String, Number],
+    default: null
+  },
+  // 사용자 이름 (alt 텍스트용)
+  name: {
+    type: String,
+    default: '사용자'
+  },
+  // alt 속성
+  alt: {
+    type: String,
+    default: null
+  },
+  // 크기 (xs, sm, md, lg, xl)
+  size: {
+    type: String,
+    default: 'md',
+    validator: value => ['xs', 'sm', 'md', 'lg', 'xl'].includes(value)
+  },
+  // 원형 여부
+  circular: {
+    type: Boolean,
+    default: true
+  },
+  // 모서리 둥글게
+  rounded: {
+    type: Boolean,
+    default: false
+  },
+  // 상태 표시 (online, offline, away 등)
+  status: {
+    type: String,
+    default: null
+  },
+  // 상태 표시 여부
+  showStatus: {
+    type: Boolean,
+    default: false
+  },
+  // 기본 이미지 타입 (dicebear, initials, default)
+  fallbackType: {
+    type: String,
+    default: 'dicebear',
+    validator: value => ['dicebear', 'initials', 'default'].includes(value)
+  }
+})
+
+const currentSrc = ref('')
+const hasError = ref(false)
+
+// 크기 클래스 계산
+const sizeClass = computed(() => `profile-image-${props.size}`)
+
+// alt 텍스트 계산
+const computedAlt = computed(() => props.alt || props.name)
+
+// fallback 이미지 URL 생성
+const getFallbackUrl = () => {
+  if (props.fallbackType === 'dicebear' && props.userId) {
+    return `https://api.dicebear.com/7.x/avataaars/svg?seed=${props.userId}`
+  } else if (props.fallbackType === 'initials' && props.name) {
+    // 이니셜 기반 이미지 (추후 구현 가능)
+    return `https://ui-avatars.com/api/?name=${encodeURIComponent(props.name)}&background=random`
+  } else {
+    return '/default-avatar.png'
+  }
+}
+
+// 이미지 에러 핸들링
+const handleImageError = () => {
+  if (!hasError.value) {
+    hasError.value = true
+    currentSrc.value = getFallbackUrl()
+  }
+}
+
+// 이미지 로드 성공
+const handleImageLoad = () => {
+  hasError.value = false
+}
+
+// src 변경 시 처리
+watch(() => props.src, (newSrc) => {
+  hasError.value = false
+  if (newSrc && newSrc.trim()) {
+    currentSrc.value = newSrc
+  } else {
+    currentSrc.value = getFallbackUrl()
+  }
+}, { immediate: true })
+</script>
+
+<style scoped>
+.profile-image-container {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.profile-image {
+  display: block;
+  object-fit: cover;
+  background-color: #f0f0f0;
+  transition: opacity 0.3s ease;
+}
+
+.profile-image.circular {
+  border-radius: 50%;
+}
+
+.profile-image.rounded {
+  border-radius: 8px;
+}
+
+/* 크기별 스타일 */
+.profile-image-xs {
+  width: 24px;
+  height: 24px;
+}
+
+.profile-image-xs .profile-image {
+  width: 24px;
+  height: 24px;
+}
+
+.profile-image-sm {
+  width: 32px;
+  height: 32px;
+}
+
+.profile-image-sm .profile-image {
+  width: 32px;
+  height: 32px;
+}
+
+.profile-image-md {
+  width: 48px;
+  height: 48px;
+}
+
+.profile-image-md .profile-image {
+  width: 48px;
+  height: 48px;
+}
+
+.profile-image-lg {
+  width: 64px;
+  height: 64px;
+}
+
+.profile-image-lg .profile-image {
+  width: 64px;
+  height: 64px;
+}
+
+.profile-image-xl {
+  width: 96px;
+  height: 96px;
+}
+
+.profile-image-xl .profile-image {
+  width: 96px;
+  height: 96px;
+}
+
+/* 상태 표시 */
+.status-indicator {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.status-indicator.online {
+  background-color: #10b981;
+}
+
+.status-indicator.offline {
+  background-color: #6b7280;
+}
+
+.status-indicator.away {
+  background-color: #f59e0b;
+}
+
+.status-indicator.busy {
+  background-color: #ef4444;
+}
+
+/* 큰 크기에서는 상태 표시도 크게 */
+.profile-image-lg .status-indicator,
+.profile-image-xl .status-indicator {
+  width: 16px;
+  height: 16px;
+  bottom: 4px;
+  right: 4px;
+}
+</style>

--- a/src/components/common/README.md
+++ b/src/components/common/README.md
@@ -1,0 +1,194 @@
+# ProfileImage 컴포넌트 사용 가이드
+
+## 개요
+ProfileImage 컴포넌트는 백엔드 User 엔티티의 `profileImage` 필드와 완벽하게 연동되어, 프로젝트 전체에서 프로필 이미지를 일관성 있게 표시하는 공통 컴포넌트입니다.
+
+## 주요 기능
+- 백엔드 User 엔티티의 profileImage 우선 지원
+- 자동 fallback 이미지 처리 (dicebear, initials, custom)
+- 다양한 크기 지원 (xs, sm, md, lg, xl)
+- 원형/둥근 모서리 스타일
+- 상태 표시 (온라인/오프라인 등)
+- 이미지 로드 에러 자동 처리
+
+## 기본 사용법
+
+```vue
+<template>
+  <ProfileImage 
+    :src="user.profileImage"
+    :user-id="user.userId"
+    :name="user.nickname"
+    size="md"
+    :circular="true"
+  />
+</template>
+
+<script setup>
+import ProfileImage from '@/components/common/ProfileImage.vue'
+</script>
+```
+
+## Props 설명
+
+### 필수 Props
+- `user-id` (String|Number): 사용자 ID (fallback 이미지 생성용)
+- `name` (String): 사용자 이름 (alt 텍스트용)
+
+### 선택 Props
+- `src` (String): 프로필 이미지 URL (백엔드의 profileImage 필드)
+- `size` (String): 'xs', 'sm', 'md', 'lg', 'xl' 중 하나 (기본값: 'md')
+- `circular` (Boolean): 원형 여부 (기본값: true)
+- `rounded` (Boolean): 둥근 모서리 여부 (기본값: false)
+- `status` (String): 상태 ('online', 'offline', 'away', 'busy')
+- `show-status` (Boolean): 상태 표시 여부 (기본값: false)
+- `fallback-type` (String): fallback 이미지 타입 ('dicebear', 'initials', 'default')
+- `alt` (String): 커스텀 alt 텍스트
+
+## 크기별 사용 예시
+
+### 작은 크기 (채팅, 댓글)
+```vue
+<ProfileImage 
+  :src="user.profileImage"
+  :user-id="user.userId"
+  :name="user.nickname"
+  size="xs"
+/>
+```
+
+### 중간 크기 (카드, 리스트)
+```vue
+<ProfileImage 
+  :src="user.profileImage"
+  :user-id="user.userId"
+  :name="user.nickname"
+  size="md"
+/>
+```
+
+### 큰 크기 (프로필 페이지)
+```vue
+<ProfileImage 
+  :src="user.profileImage"
+  :user-id="user.userId"
+  :name="user.nickname"
+  size="xl"
+/>
+```
+
+## 상태 표시 사용법
+```vue
+<ProfileImage 
+  :src="user.profileImage"
+  :user-id="user.userId"
+  :name="user.nickname"
+  size="md"
+  status="online"
+  :show-status="true"
+/>
+```
+
+## 컴포지블과 함께 사용
+
+```vue
+<template>
+  <ProfileImage 
+    :src="profileImageUrl"
+    :user-id="userId"
+    :name="userName"
+    size="md"
+  />
+</template>
+
+<script setup>
+import ProfileImage from '@/components/common/ProfileImage.vue'
+import { useProfileImage } from '@/composables/useProfileImage.js'
+
+const props = defineProps(['user'])
+
+const { profileImageUrl, userName, userId } = useProfileImage(props.user)
+</script>
+```
+
+## 마이그레이션 가이드
+
+### 기존 코드
+```vue
+<!-- 기존 방식 -->
+<img 
+  :src="getMemberProfileImage(member)" 
+  :alt="member.name"
+  class="profile-image"
+  @error="handleImageError"
+/>
+```
+
+### 새로운 코드
+```vue
+<!-- 새로운 방식 -->
+<ProfileImage 
+  :src="member.profileImage"
+  :user-id="member.userId"
+  :name="member.name"
+  size="md"
+/>
+```
+
+## 백엔드 연동
+
+이 컴포넌트는 백엔드 User 엔티티의 다음 필드들과 연동됩니다:
+
+```java
+// User.java
+@Column(columnDefinition = "text")
+private String profileImage;  // 우선순위 1
+
+@Column(nullable = false, columnDefinition = "citext")
+private String nickname;      // 사용자 이름
+
+@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+private Long userId;          // 사용자 ID
+```
+
+## Fallback 처리 순서
+
+1. `user.profileImage` (백엔드에서 제공)
+2. `user.avatar` (기존 호환성)
+3. Dicebear 자동 생성 아바타
+4. 기본 이미지
+
+## 스타일 커스터마이징
+
+컴포넌트에 추가 클래스를 적용할 수 있습니다:
+
+```vue
+<ProfileImage 
+  :src="user.profileImage"
+  :user-id="user.userId"
+  :name="user.nickname"
+  size="md"
+  class="custom-border"
+/>
+
+<style>
+.custom-border {
+  border: 2px solid #007bff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+</style>
+```
+
+## 주의사항
+
+1. **userId는 필수입니다** - fallback 이미지 생성에 필요
+2. **profileImage가 우선됩니다** - 백엔드 필드와 완벽 연동
+3. **에러 처리가 자동화되어 있습니다** - 별도 에러 핸들링 불필요
+4. **반응형 디자인을 고려하세요** - 다양한 화면 크기에서 테스트
+
+## 성능 최적화
+
+- lazy loading 자동 적용
+- 이미지 캐싱 최적화
+- fallback 이미지 미리 로드
+- 불필요한 리렌더링 방지

--- a/src/components/portfolio/ProjectSelectionModal.vue
+++ b/src/components/portfolio/ProjectSelectionModal.vue
@@ -7,13 +7,13 @@
           <i class="bi bi-x"></i>
         </button>
       </div>
-      
+
       <div class="modal-body">
         <div v-if="loading" class="loading-state">
           <div class="loading-spinner"></div>
           <p>프로젝트를 불러오는 중...</p>
         </div>
-        
+
         <div v-else-if="projects.length === 0" class="empty-state">
           <div class="empty-icon">
             <i class="bi bi-folder-x"></i>
@@ -21,56 +21,75 @@
           <h4>참여한 프로젝트가 없습니다</h4>
           <p>프로젝트에 참여한 후 다시 시도해보세요.</p>
         </div>
-        
+
         <div v-else class="projects-section">
           <div class="selection-info">
             <div class="info-text">
               <i class="bi bi-info-circle"></i>
-              공개할 프로젝트를 선택하세요. 선택한 프로젝트는 포트폴리오에 표시됩니다.
+              공개할 프로젝트를 선택하세요. 선택한 프로젝트는 포트폴리오에
+              표시됩니다.
             </div>
             <div class="selection-count">
               {{ selectedProjects.length }}개 선택됨
             </div>
           </div>
-          
+
           <div class="projects-list">
-            <div 
-              v-for="project in projects" 
+            <div
+              v-for="project in projects"
               :key="project.projectId"
-              :class="['project-item', { 'selected': isProjectSelected(project.projectId) }]"
+              :class="[
+                'project-item',
+                { selected: isProjectSelected(project.projectId) },
+              ]"
               @click="toggleProject(project)"
             >
               <div class="project-checkbox">
-                <input 
-                  type="checkbox" 
+                <input
+                  type="checkbox"
                   :checked="isProjectSelected(project.projectId)"
                   @click.stop
                   @change="toggleProject(project)"
                 />
               </div>
-              
+
               <div class="project-info">
                 <div class="project-header">
                   <h4 class="project-title">{{ project.title }}</h4>
                   <div class="project-badges">
-                    <span :class="['status-badge', getStatusClass(project.status)]">
+                    <span
+                      :class="['status-badge', getStatusClass(project.status)]"
+                    >
                       {{ getStatusText(project.status) }}
                     </span>
                     <span v-if="project.isPM" class="pm-badge">PM</span>
                   </div>
                 </div>
-                
+
                 <p class="project-description">{{ project.description }}</p>
-                
+
                 <div class="project-meta">
                   <div class="meta-item">
                     <i class="bi bi-calendar"></i>
-                    <span>{{ formatDateRange(project.startDate, project.endDate) }}</span>
+                    <span>{{
+                      formatDateRange(project.startDate, project.endDate)
+                    }}</span>
                   </div>
-                  <div class="meta-item" v-if="project.techStacks && project.techStacks.length > 0">
+                  <div
+                    class="meta-item"
+                    v-if="project.techStacks && project.techStacks.length > 0"
+                  >
                     <i class="bi bi-code-slash"></i>
-                    <span>{{ project.techStacks.slice(0, 2).map(ts => ts.techStackName || ts.name || ts).join(', ') }}
-                      <span v-if="project.techStacks.length > 2"> 외 {{ project.techStacks.length - 2 }}개</span>
+                    <span
+                      >{{
+                        project.techStacks
+                          .slice(0, 2)
+                          .map((ts) => ts.techStackName || ts.name || ts)
+                          .join(", ")
+                      }}
+                      <span v-if="project.techStacks.length > 2">
+                        외 {{ project.techStacks.length - 2 }}개</span
+                      >
                     </span>
                   </div>
                 </div>
@@ -79,11 +98,9 @@
           </div>
         </div>
       </div>
-      
+
       <div class="modal-footer">
-        <button @click="closeModal" class="cancel-btn">
-          취소
-        </button>
+        <button @click="closeModal" class="cancel-btn">취소</button>
         <button @click="saveSelection" class="save-btn" :disabled="loading">
           <i class="bi bi-check-circle"></i>
           선택 완료 ({{ selectedProjects.length }}개)
@@ -94,153 +111,159 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
-import { getProjectsCreatedByUser, getAppliedProjectsByUser } from '@/api/projects'
-import { portfolioApi } from '@/api/portfolio.js'
-import { useUserStore } from '@/stores/userStore'
-import { useToast } from 'vue-toastification'
+import { ref, computed, onMounted, watch } from "vue";
+import {
+  getProjectsCreatedByUser,
+  getAppliedProjectsByUser,
+} from "@/api/projects";
+import { portfolioApi } from "@/api/portfolio.js";
+import { useUserStore } from "@/stores/userStore";
 
 const props = defineProps({
   show: {
     type: Boolean,
-    default: false
-  }
-})
+    default: false,
+  },
+});
 
-const emit = defineEmits(['close', 'saved'])
+const emit = defineEmits(["close", "saved"]);
 
-const userStore = useUserStore()
-const toast = useToast()
-const loading = ref(false)
-const saving = ref(false)
-const projects = ref([])
-const selectedProjects = ref([])
+const userStore = useUserStore();
+const loading = ref(false);
+const saving = ref(false);
+const projects = ref([]);
+const selectedProjects = ref([]);
 
 // 프로젝트 데이터 로드
 const loadProjects = async () => {
-  loading.value = true
+  loading.value = true;
   try {
     // 백엔드의 통합 API 사용
     const response = await portfolioApi.getAvailableProjects();
-    
+
     // 응답 데이터를 모달 형식으로 변환
-    projects.value = response.data.map(project => ({
+    projects.value = response.data.map((project) => ({
       projectId: project.projectId,
-      title: project.title || '',
-      description: project.description || '',
-      status: project.status || 'RECRUITING',
+      title: project.title || "",
+      description: project.description || "",
+      status: project.status || "RECRUITING",
       startDate: project.startDate,
       endDate: project.endDate,
       techStacks: project.techStacks || [],
-      isPM: project.role === 'LEADER' || project.role === 'PM'
+      isPM: project.role === "LEADER" || project.role === "PM",
     }));
-    
+
     // 현재 선택된 프로젝트 ID들 추출
     selectedProjects.value = response.data
-      .filter(project => project.selectedInPortfolio)
-      .map(project => project.projectId);
-    
+      .filter((project) => project.selectedInPortfolio)
+      .map((project) => project.projectId);
   } catch (error) {
-    console.error('프로젝트 로드 실패:', error)
-    projects.value = []
+    console.error("프로젝트 로드 실패:", error);
+    projects.value = [];
   } finally {
-    loading.value = false
+    loading.value = false;
   }
-}
-
+};
 
 // 프로젝트 선택 토글
 const toggleProject = (project) => {
-  const projectId = project.projectId
-  const index = selectedProjects.value.indexOf(projectId)
-  
+  const projectId = project.projectId;
+  const index = selectedProjects.value.indexOf(projectId);
+
   if (index > -1) {
-    selectedProjects.value.splice(index, 1)
+    selectedProjects.value.splice(index, 1);
   } else {
-    selectedProjects.value.push(projectId)
+    selectedProjects.value.push(projectId);
   }
-}
+};
 
 // 프로젝트가 선택되었는지 확인
 const isProjectSelected = (projectId) => {
-  return selectedProjects.value.includes(projectId)
-}
+  return selectedProjects.value.includes(projectId);
+};
 
 // 선택 저장
 const saveSelection = async () => {
-  if (saving.value) return
-  
-  saving.value = true
+  if (saving.value) return;
+
+  saving.value = true;
   try {
-    const response = await portfolioApi.updateProjectSelection(selectedProjects.value)
-    emit('saved')
-    toast.success('포트폴리오에 반영할 프로젝트를 저장했습니다.')
-    closeModal()
+    const response = await portfolioApi.updateProjectSelection(
+      selectedProjects.value
+    );
+    emit("saved");
+    closeModal();
   } catch (error) {
-    console.error('프로젝트 선택 저장 실패:', error)
-    toast.error('프로젝트 선택을 저장하는데 실패했습니다.')
+    console.error("프로젝트 선택 저장 실패:", error);
+    alert("프로젝트 선택을 저장하는데 실패했습니다.");
   } finally {
-    saving.value = false
+    saving.value = false;
   }
-}
+};
 
 // 모달 닫기
 const closeModal = () => {
-  emit('close')
-}
+  emit("close");
+};
 
 // 상태 관련 유틸리티
 const getStatusClass = (status) => {
   const statusMap = {
-    'RECRUITING': 'recruiting',
-    'IN_PROGRESS': 'in-progress', 
-    'COMPLETED': 'completed',
-    'CANCELLED': 'cancelled'
-  }
-  return statusMap[status] || 'recruiting'
-}
+    RECRUITING: "recruiting",
+    IN_PROGRESS: "in-progress",
+    COMPLETED: "completed",
+    CANCELLED: "cancelled",
+  };
+  return statusMap[status] || "recruiting";
+};
 
 const getStatusText = (status) => {
   const statusMap = {
-    'RECRUITING': '모집중',
-    'IN_PROGRESS': '진행중',
-    'COMPLETED': '완료',
-    'CANCELLED': '취소됨'
-  }
-  return statusMap[status] || status
-}
+    RECRUITING: "모집중",
+    IN_PROGRESS: "진행중",
+    COMPLETED: "완료",
+    CANCELLED: "취소됨",
+  };
+  return statusMap[status] || status;
+};
 
 const formatDateRange = (startDate, endDate) => {
-  if (!startDate && !endDate) return '-'
-  
+  if (!startDate && !endDate) return "-";
+
   const formatDate = (dateStr) => {
-    if (!dateStr) return '?'
-    const date = new Date(dateStr)
-    return date.toLocaleDateString('ko-KR', { 
-      year: 'numeric', 
-      month: 'short', 
-      day: 'numeric' 
-    }).replace(/\. /g, '.').replace(/\.$/, '')
-  }
-  
-  const start = formatDate(startDate)
-  const end = endDate ? formatDate(endDate) : '진행중'
-  
-  return `${start} ~ ${end}`
-}
+    if (!dateStr) return "?";
+    const date = new Date(dateStr);
+    return date
+      .toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+      .replace(/\. /g, ".")
+      .replace(/\.$/, "");
+  };
+
+  const start = formatDate(startDate);
+  const end = endDate ? formatDate(endDate) : "진행중";
+
+  return `${start} ~ ${end}`;
+};
 
 // 모달이 열릴 때 데이터 로드
-watch(() => props.show, (newShow) => {
-  if (newShow) {
-    loadProjects()
+watch(
+  () => props.show,
+  (newShow) => {
+    if (newShow) {
+      loadProjects();
+    }
   }
-})
+);
 
 onMounted(() => {
   if (props.show) {
-    loadProjects()
+    loadProjects();
   }
-})
+});
 </script>
 
 <style scoped>
@@ -288,7 +311,7 @@ onMounted(() => {
   align-items: center;
   padding: 24px 30px;
   border-bottom: 2px solid #f0f0f0;
-  background: linear-gradient(135deg, #4CAF50, #66BB6A);
+  background: linear-gradient(135deg, #4caf50, #66bb6a);
   color: white;
 }
 
@@ -335,14 +358,18 @@ onMounted(() => {
   width: 40px;
   height: 40px;
   border: 4px solid #f3f3f3;
-  border-top: 4px solid #4CAF50;
+  border-top: 4px solid #4caf50;
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .empty-state {
@@ -365,7 +392,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   font-size: 36px;
-  color: #4CAF50;
+  color: #4caf50;
   margin-bottom: 8px;
 }
 
@@ -402,13 +429,13 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: #4CAF50;
+  color: #4caf50;
   font-size: 14px;
   font-weight: 500;
 }
 
 .selection-count {
-  background: #4CAF50;
+  background: #4caf50;
   color: white;
   padding: 6px 16px;
   border-radius: 20px;
@@ -442,7 +469,7 @@ onMounted(() => {
 }
 
 .project-item.selected {
-  border-color: #4CAF50;
+  border-color: #4caf50;
   background: rgba(76, 175, 80, 0.05);
   box-shadow: 0 4px 12px rgba(76, 175, 80, 0.15);
 }
@@ -455,7 +482,7 @@ onMounted(() => {
   width: 20px;
   height: 20px;
   cursor: pointer;
-  accent-color: #4CAF50;
+  accent-color: #4caf50;
 }
 
 .project-info {
@@ -516,7 +543,7 @@ onMounted(() => {
 }
 
 .pm-badge {
-  background: linear-gradient(135deg, #FFD700, #FFA000);
+  background: linear-gradient(135deg, #ffd700, #ffa000);
   color: #fff;
   padding: 4px 8px;
   border-radius: 12px;
@@ -551,7 +578,7 @@ onMounted(() => {
 }
 
 .meta-item i {
-  color: #4CAF50;
+  color: #4caf50;
 }
 
 .modal-footer {
@@ -568,7 +595,7 @@ onMounted(() => {
   border: 2px solid rgba(76, 175, 80, 0.2);
   border-radius: 8px;
   background: #fff;
-  color: #4CAF50;
+  color: #4caf50;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -576,7 +603,7 @@ onMounted(() => {
 }
 
 .cancel-btn:hover {
-  border-color: #4CAF50;
+  border-color: #4caf50;
   background: rgba(76, 175, 80, 0.05);
 }
 
@@ -587,7 +614,7 @@ onMounted(() => {
   padding: 12px 24px;
   border: none;
   border-radius: 8px;
-  background: #4CAF50;
+  background: #4caf50;
   color: #fff;
   font-size: 14px;
   font-weight: 600;
@@ -596,7 +623,7 @@ onMounted(() => {
 }
 
 .save-btn:hover:not(:disabled) {
-  background: #66BB6A;
+  background: #66bb6a;
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
 }

--- a/src/components/portfolioComponents/ProjectsSection.vue
+++ b/src/components/portfolioComponents/ProjectsSection.vue
@@ -23,7 +23,7 @@
       <div v-else class="projects-content">
         <div class="projects-grid">
           <div 
-            v-for="(project, index) in processedProjects" 
+            v-for="(project, index) in paginatedProjects" 
             :key="index"
             class="project-card-wrapper"
           >
@@ -55,13 +55,23 @@
             </div>
           </div>
         </div>
+        
+        <!-- 페이지네이션 (3개 이상일 때만 표시) -->
+        <PaginationComponent 
+          v-if="processedProjects.length > 3"
+          :current-page="currentProjectPage" 
+          :total-pages="totalProjectPages" 
+          :page-group-size="3" 
+          @page-change="handleProjectPageChange" 
+        />
       </div>
     </div>
   </section>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import PaginationComponent from '@/components/common/PaginationComponent.vue'
 
 // Props
 const props = defineProps({
@@ -128,6 +138,10 @@ const getRoleBadgeColor = (role) => {
   }
 }
 
+// 페이지네이션 상태
+const currentProjectPage = ref(1)
+const projectsPerPage = 3
+
 // 처리된 프로젝트 데이터
 const processedProjects = computed(() => {
   return props.projects.map(project => ({
@@ -146,6 +160,22 @@ const processedProjects = computed(() => {
     ]
   }))
 })
+
+// 페이지네이션 계산
+const totalProjectPages = computed(() => {
+  return Math.ceil(processedProjects.value.length / projectsPerPage)
+})
+
+const paginatedProjects = computed(() => {
+  const start = (currentProjectPage.value - 1) * projectsPerPage
+  const end = start + projectsPerPage
+  return processedProjects.value.slice(start, end)
+})
+
+// 페이지 변경 핸들러
+const handleProjectPageChange = (page) => {
+  currentProjectPage.value = page
+}
 </script>
 
 <style scoped>

--- a/src/components/portfolioComponents/ReviewSection.vue
+++ b/src/components/portfolioComponents/ReviewSection.vue
@@ -16,7 +16,7 @@
       
       <div v-else class="review-list">
         <div 
-          v-for="(review, index) in processedReviews" 
+          v-for="(review, index) in paginatedReviews" 
           :key="review.reviewId || index"
           class="review-item"
         >
@@ -56,13 +56,23 @@
             </div>
           </div>
         </div>
+        
+        <!-- 페이지네이션 (3개 이상일 때만 표시) -->
+        <PaginationComponent 
+          v-if="processedReviews.length > 4"
+          :current-page="currentReviewPage" 
+          :total-pages="totalReviewPages" 
+          :page-group-size="3" 
+          @page-change="handleReviewPageChange" 
+        />
       </div>
     </div>
   </section>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import PaginationComponent from '@/components/common/PaginationComponent.vue'
 
 // Props
 const props = defineProps({
@@ -102,6 +112,10 @@ const formatReviewDate = (dateString) => {
   }
 }
 
+// 페이지네이션 상태
+const currentReviewPage = ref(1)
+const reviewsPerPage = 4
+
 // 처리된 리뷰 데이터
 const processedReviews = computed(() => {
   return props.reviews.map(review => ({
@@ -110,6 +124,22 @@ const processedReviews = computed(() => {
     timeAgo: formatReviewDate(review.createdAt)
   }))
 })
+
+// 페이지네이션 계산
+const totalReviewPages = computed(() => {
+  return Math.ceil(processedReviews.value.length / reviewsPerPage)
+})
+
+const paginatedReviews = computed(() => {
+  const start = (currentReviewPage.value - 1) * reviewsPerPage
+  const end = start + reviewsPerPage
+  return processedReviews.value.slice(start, end)
+})
+
+// 페이지 변경 핸들러
+const handleReviewPageChange = (page) => {
+  currentReviewPage.value = page
+}
 
 // 이미지 에러 핸들링
 const handleImageError = (event) => {

--- a/src/components/recommendations/TeamMemberRecommendationTab.vue
+++ b/src/components/recommendations/TeamMemberRecommendationTab.vue
@@ -75,12 +75,12 @@
       >
         <!-- 프로필 헤더 -->
         <div class="member-header">
-          <img 
-            :src="getMemberProfileImage(member)" 
-            :alt="member.name || member.nickname"
-            class="profile-image"
-            @error="handleMemberImageError($event, member.userId)"
-            loading="lazy"
+          <ProfileImage 
+            :src="member.profileImage"
+            :user-id="member.userId"
+            :name="member.name || member.nickname"
+            size="md"
+            :circular="true"
           />
           <div class="member-info">
             <h4 class="member-name">{{ member.name || member.nickname }}</h4>
@@ -199,6 +199,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import ProfileImage from '@/components/common/ProfileImage.vue'
 
 // 날짜 포맷팅 함수
 const formatDate = (dateString) => {
@@ -292,17 +293,6 @@ const getMemberTechStacks = (member) => {
   }
 }
 
-// 프로필 이미지 처리
-const getMemberProfileImage = (member) => {
-  if (member.profileImage && 
-      member.profileImage.startsWith('http') && 
-      !member.profileImage.includes('example.com') &&
-      !member.profileImage.includes('placeholder')) {
-    return member.profileImage
-  }
-  
-  return `https://api.dicebear.com/7.x/avataaars/svg?seed=${member.userId}&backgroundColor=b6e3f4,c0aede,d1d4f9,ffd5dc,ffdfbf`
-}
 
 // 매칭도 점수에 따른 클래스 분류
 const getScoreClass = (score) => {
@@ -328,34 +318,6 @@ const getAvailabilityClass = (member) => {
   return 'available' // 기본값
 }
 
-const handleMemberImageError = (event, userId) => {
-  console.warn(`팀원 프로필 이미지 로드 실패 (사용자 ${userId}):`, event.target.src)
-  
-  if (!event.target.src.includes('dicebear.com')) {
-    event.target.src = `https://api.dicebear.com/7.x/avataaars/svg?seed=${userId}&backgroundColor=b6e3f4,c0aede,d1d4f9,ffd5dc,ffdfbf`
-    return
-  }
-  
-  if (event.target.src.includes('avataaars')) {
-    event.target.src = `https://api.dicebear.com/7.x/initials/svg?seed=User${userId}&backgroundColor=4f46e5,7c3aed,db2777,dc2626,ea580c`
-    return
-  }
-  
-  if (event.target.src.includes('initials')) {
-    event.target.src = `https://api.dicebear.com/7.x/shapes/svg?seed=${userId}&backgroundColor=22c55e,3b82f6,8b5cf6,f59e0b,ef4444`
-    return
-  }
-  
-  if (event.target.src.includes('shapes')) {
-    event.target.src = `https://ui-avatars.com/api/?name=User${userId}&background=4CAF50&color=fff&size=60`
-    return
-  }
-  
-  // 모든 API 실패 시
-  event.target.style.opacity = '0'
-  event.target.style.background = 'linear-gradient(135deg, #4CAF50, #81C784)'
-  event.target.alt = 'U'
-}
 </script>
 
 <style scoped>
@@ -615,20 +577,6 @@ const handleMemberImageError = (event, userId) => {
   position: relative;
 }
 
-.profile-image {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid #e9ecef;
-  background: linear-gradient(135deg, #4CAF50, #81C784);
-  transition: all 0.2s ease;
-}
-
-.profile-image:hover {
-  transform: scale(1.05);
-  border-color: #4CAF50;
-}
 
 .member-info {
   flex: 1;

--- a/src/composables/useProfileImage.js
+++ b/src/composables/useProfileImage.js
@@ -1,0 +1,128 @@
+import { ref, computed } from 'vue'
+
+/**
+ * 프로필 이미지 관련 로직을 처리하는 컴포지블
+ * @param {Object} user - 사용자 객체
+ * @param {Object} options - 옵션 설정
+ */
+export function useProfileImage(user = {}, options = {}) {
+  const {
+    fallbackType = 'dicebear',
+    defaultImage = '/default-avatar.png'
+  } = options
+
+  // 이미지 에러 상태
+  const hasImageError = ref(false)
+
+  /**
+   * 프로필 이미지 URL 반환
+   * 우선순위: profileImage > avatar > fallback
+   */
+  const profileImageUrl = computed(() => {
+    // 백엔드 User 엔티티의 profileImage 필드 우선
+    if (user.profileImage && !hasImageError.value) {
+      return user.profileImage
+    }
+    
+    // avatar 필드 (기존 호환성)
+    if (user.avatar && !hasImageError.value) {
+      return user.avatar
+    }
+    
+    // fallback 이미지 생성
+    return getFallbackImageUrl(user, fallbackType, defaultImage)
+  })
+
+  /**
+   * 사용자 이름 반환
+   * 우선순위: name > nickname > 기본값
+   */
+  const userName = computed(() => {
+    return user.name || user.nickname || '사용자'
+  })
+
+  /**
+   * 사용자 ID 반환
+   * 우선순위: userId > id
+   */
+  const userId = computed(() => {
+    return user.userId || user.id || null
+  })
+
+  /**
+   * 이미지 에러 처리
+   */
+  const handleImageError = () => {
+    hasImageError.value = true
+  }
+
+  /**
+   * 이미지 로드 성공 처리
+   */
+  const handleImageLoad = () => {
+    hasImageError.value = false
+  }
+
+  /**
+   * 이미지 에러 상태 리셋
+   */
+  const resetImageError = () => {
+    hasImageError.value = false
+  }
+
+  return {
+    profileImageUrl,
+    userName,
+    userId,
+    hasImageError,
+    handleImageError,
+    handleImageLoad,
+    resetImageError
+  }
+}
+
+/**
+ * fallback 이미지 URL 생성
+ */
+function getFallbackImageUrl(user, fallbackType, defaultImage) {
+  const userId = user.userId || user.id
+  const userName = user.name || user.nickname
+
+  switch (fallbackType) {
+    case 'dicebear':
+      if (userId) {
+        return `https://api.dicebear.com/7.x/avataaars/svg?seed=${userId}`
+      }
+      break
+    
+    case 'initials':
+      if (userName) {
+        return `https://ui-avatars.com/api/?name=${encodeURIComponent(userName)}&background=random&color=fff`
+      }
+      break
+    
+    case 'robohash':
+      if (userId) {
+        return `https://robohash.org/${userId}?set=set4&size=200x200`
+      }
+      break
+  }
+  
+  return defaultImage
+}
+
+/**
+ * 멤버 프로필 이미지 URL 반환 (기존 함수와 호환성)
+ */
+export function getMemberProfileImage(member, fallbackType = 'dicebear') {
+  const { profileImageUrl } = useProfileImage(member, { fallbackType })
+  return profileImageUrl.value
+}
+
+/**
+ * 아바타 URL 반환 (기존 함수와 호환성)
+ */
+export function getAvatarUrl(user, fallbackType = 'dicebear') {
+  const { profileImageUrl } = useProfileImage(user, { fallbackType })
+  return profileImageUrl.value
+}

--- a/src/views/FavoritesPage.vue
+++ b/src/views/FavoritesPage.vue
@@ -58,9 +58,14 @@
             <div v-for="portfolio in favoritePortfolios" :key="portfolio.userId" class="content-card portfolio-card">
               <div class="card-header">
                 <div class="portfolio-profile">
-                  <div class="profile-avatar">
-                    <img :src="portfolio.profileImage || 'default-avatar.png'" :alt="portfolio.nickname" />
-                  </div>
+                  <ProfileImage 
+                    :src="portfolio.profileImage"
+                    :user-id="portfolio.userId"
+                    :name="portfolio.nickname"
+                    size="md"
+                    :circular="true"
+                    class="profile-avatar"
+                  />
                   <div class="profile-details">
                     <h3 class="profile-name">{{ portfolio.nickname }}</h3>
                     <p class="profile-job">{{ portfolio.jobTitle }}</p>
@@ -122,6 +127,7 @@ import { getLikedProjects, getLikedPortfolios, toggleLike } from '@/api/likes.js
 import { useToast } from 'vue-toastification'
 import PaginationComponent from '@/components/projectComponents/PaginationComponent.vue'
 import ProjectCard from '@/components/projectComponents/ProjectCard.vue'
+import ProfileImage from '@/components/common/ProfileImage.vue'
 
 const router = useRouter()
 const userStore = useUserStore()

--- a/src/views/MyPortfolioPage.vue
+++ b/src/views/MyPortfolioPage.vue
@@ -577,7 +577,7 @@
           <div v-if="portfolioData.reviews.length > 0" class="section-content">
             <div class="reviews-list">
               <div 
-                v-for="review in portfolioData.reviews" 
+                v-for="review in paginatedReviews" 
                 :key="review.reviewId"
                 class="review-card"
               >
@@ -618,6 +618,15 @@
                 </div>
               </div>
             </div>
+            
+            <!-- 페이지네이션 (4개 이상일 때만 표시) -->
+            <PaginationComponent 
+              v-if="portfolioData.reviews.length > 4"
+              :current-page="currentReviewPage" 
+              :total-pages="totalReviewPages" 
+              :page-group-size="3" 
+              @page-change="handleReviewPageChange" 
+            />
           </div>
           
           <div v-else class="empty-section">
@@ -661,6 +670,7 @@ import { portfolioApi, techStackApi } from '@/api/portfolio.js'
 import api from '@/api/axios.js'
 import ProjectSelectionModal from '@/components/portfolio/ProjectSelectionModal.vue'
 import ProfileImage from '@/components/common/ProfileImage.vue'
+import PaginationComponent from '@/components/common/PaginationComponent.vue'
 
 const router = useRouter()
 
@@ -705,6 +715,26 @@ const portfolioData = reactive({
   projects: [],
   reviews: []
 })
+
+// 리뷰 페이지네이션 상태
+const currentReviewPage = ref(1)
+const reviewsPerPage = 4
+
+// 리뷰 페이지네이션 계산
+const totalReviewPages = computed(() => {
+  return Math.ceil(portfolioData.reviews.length / reviewsPerPage)
+})
+
+const paginatedReviews = computed(() => {
+  const start = (currentReviewPage.value - 1) * reviewsPerPage
+  const end = start + reviewsPerPage
+  return portfolioData.reviews.slice(start, end)
+})
+
+// 리뷰 페이지 변경 핸들러
+const handleReviewPageChange = (page) => {
+  currentReviewPage.value = page
+}
 
 // 편집용 데이터
 const editData = reactive({})

--- a/src/views/MyPortfolioPage.vue
+++ b/src/views/MyPortfolioPage.vue
@@ -9,14 +9,14 @@
       <div class="portfolio-header">
         <div class="header-content">
           <div class="profile-section">
-            <div class="profile-image">
-              <img 
-                :src="portfolioData.userInfo.avatar" 
-                :alt="portfolioData.userInfo.name" 
-                @error="handleImageError"
-                :onerror="`this.src='https://api.dicebear.com/7.x/avataaars/svg?seed=${portfolioData.userInfo.userId || 'default'}'`"
-              />
-            </div>
+            <ProfileImage 
+              :src="portfolioData.userInfo.avatar"
+              :user-id="portfolioData.userInfo.userId"
+              :name="portfolioData.userInfo.name"
+              size="xl"
+              :circular="true"
+              class="profile-image"
+            />
             
             <div class="profile-info">
               <h1 class="profile-name">
@@ -583,13 +583,14 @@
               >
                 <div class="review-header">
                   <div class="reviewer-info">
-                    <div class="reviewer-avatar">
-                      <img 
-                        :src="review.reviewerProfileImage || `https://api.dicebear.com/7.x/avataaars/svg?seed=${review.reviewerId}`" 
-                        :alt="review.reviewerNickname"
-                        @error="handleReviewerImageError"
-                      />
-                    </div>
+                    <ProfileImage 
+                      :src="review.reviewerProfileImage"
+                      :user-id="review.reviewerId"
+                      :name="review.reviewerNickname"
+                      size="sm"
+                      :circular="true"
+                      class="reviewer-avatar"
+                    />
                     <div class="reviewer-details">
                       <h6 class="reviewer-name">{{ review.reviewerNickname || '익명' }}</h6>
                       <p class="project-context">{{ review.projectTitle }}</p>
@@ -659,6 +660,7 @@ import { useRouter } from 'vue-router'
 import { portfolioApi, techStackApi } from '@/api/portfolio.js'
 import api from '@/api/axios.js'
 import ProjectSelectionModal from '@/components/portfolio/ProjectSelectionModal.vue'
+import ProfileImage from '@/components/common/ProfileImage.vue'
 
 const router = useRouter()
 
@@ -711,27 +713,6 @@ const editData = reactive({})
 const educationErrors = reactive({})
 const careerErrors = reactive({})
 
-// 이미지 로드 에러 처리
-const handleImageError = (event) => {
-  console.error('포트폴리오 프로필 이미지 로드 실패:', portfolioData.userInfo.avatar);
-  // 이미 dicebear URL이 아닌 경우에만 변경
-  if (!event.target.src.includes('dicebear.com')) {
-    event.target.src = `https://api.dicebear.com/7.x/avataaars/svg?seed=${portfolioData.userInfo.userId || 'default'}`;
-  }
-}
-
-// 리뷰어 이미지 로드 에러 처리
-const handleReviewerImageError = (event) => {
-  console.error('리뷰어 프로필 이미지 로드 실패:', event.target.src);
-  // 이미 dicebear URL이 아닌 경우에만 변경
-  if (!event.target.src.includes('dicebear.com')) {
-    // 현재 이미지의 seed를 추출하거나 기본값 사용
-    const currentSrc = event.target.src;
-    const seedMatch = currentSrc.match(/seed=([^&]*)/);
-    const seed = seedMatch ? seedMatch[1] : 'default';
-    event.target.src = `https://api.dicebear.com/7.x/avataaars/svg?seed=${seed}`;
-  }
-}
 
 // 리뷰 데이터를 가져오는 API 함수
 const getUserReviews = async (userId) => {

--- a/src/views/MyProjectListPage.vue
+++ b/src/views/MyProjectListPage.vue
@@ -277,6 +277,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { getProjectsCreatedByUser, getAppliedProjectsByUser } from '@/api/projects'
+import { portfolioApi } from '@/api/portfolio.js'
 import { useUserStore } from '@/stores/userStore';
 import { PART_OPTIONS } from '@/constants/parts';
 import { updateMemberStatus, getProjectMembers, getConfirmedProjectMembers } from '@/api/projectMember.js';
@@ -326,30 +327,6 @@ const ENUM_TO_CLASS = {
 const statusClass = (statusEnum) => ENUM_TO_CLASS[statusEnum] ?? 'unknown'
 
 // ===== 정규화 유틸 =====
-const toTechTags = (list) => {
-  if (!Array.isArray(list)) return []
-  return list.map(ts => (typeof ts === 'string' ? { techStackName: ts } : ts))
-}
-
-const normalizeProject = (p, currentUserId, isPM) => {
-  const projectId = p.projectId ?? p.id;
-  const teamLeaderId = p.teamLeaderId ?? p.leaderId ?? p.ownerId ?? (isPM ? currentUserId : null);
-  
-  return {
-    projectId,
-    title: p.title ?? '',
-    description: p.description ?? '',
-    status: p.status ?? 'RECRUITING',
-    startDate: p.startDate ?? null,
-    endDate: p.endDate ?? null,
-    recruitCount: p.recruitCount ?? 0,
-    techStacks: toTechTags(p.techStacks ?? []),
-    appliedCount: p.appliedCount ?? 0,
-    teamLeaderId,
-    isPM: teamLeaderId === currentUserId,
-    members: p.members ?? [], // 멤버 목록 추가
-  };
-};
 
 // ===== 데이터 로드 =====
 onMounted(async () => {
@@ -360,20 +337,26 @@ onMounted(async () => {
       return
     }
 
-    const [createdRes, appliedRes] = await Promise.all([
-      getProjectsCreatedByUser(currentUserId),
-      getAppliedProjectsByUser(currentUserId)
-    ])
-
-    const created = (createdRes.data || []).map(p => normalizeProject(p, currentUserId, true));
-    const applied = (appliedRes.data || []).map(a => normalizeProject(a.project || a, currentUserId, false));
-
-    const map = new Map()
-    for (const p of [...applied, ...created]) map.set(p.projectId, p)
-    projects.value = Array.from(map.values())
+    // 백엔드의 통합 API 사용
+    const response = await portfolioApi.getAvailableProjects()
+    
+    // 응답 데이터를 기존 형식에 맞게 변환
+    projects.value = (response.data || []).map(project => ({
+      projectId: project.projectId,
+      title: project.title || '',
+      description: project.description || '',
+      status: project.status || 'RECRUITING',
+      startDate: project.startDate,
+      endDate: project.endDate,
+      recruitCount: project.recruitCount || 0,
+      techStacks: project.techStacks || [],
+      isPM: project.role === 'LEADER' || project.role === 'PM',
+      role: project.role || 'MEMBER',
+      members: project.members || []
+    }))
 
   } catch (e) {
-    console.error('내 프로젝트/지원 프로젝트 로드 실패:', e)
+    console.error('내 프로젝트 로드 실패:', e)
     projects.value = []
   } finally {
     isLoading.value = false

--- a/src/views/PortfolioListPage.vue
+++ b/src/views/PortfolioListPage.vue
@@ -158,18 +158,12 @@
             </div>
           </div>
 
-          <div class="pagination-bar" v-if="totalPages > 1">
-            <button @click="goToPage(page - 1)" :disabled="page === 1">이전</button>
-            <button
-                v-for="p in totalPages"
-                :key="p"
-                :class="{ active: page === p }"
-                @click="goToPage(p)"
-            >
-              {{ p }}
-            </button>
-            <button @click="goToPage(page + 1)" :disabled="page === totalPages">다음</button>
-          </div>
+          <PaginationComponent 
+            :current-page="page" 
+            :total-pages="totalPages" 
+            :page-group-size="5" 
+            @page-change="handlePageChange" 
+          />
         </div>
       </div>
     </div>
@@ -185,6 +179,7 @@ import { useUserStore } from '@/stores/userStore';
 
 import PageHeader from '@/components/common/PageHeader.vue';
 import PortfolioCard from '@/components/portfolioComponents/PortfolioCard.vue';
+import PaginationComponent from '@/components/common/PaginationComponent.vue';
 
 import { searchUsers, getPopularUserKeywords } from '@/api/search';
 import { getPortfolios } from '@/api/user';
@@ -316,7 +311,7 @@ const performSearch = async (searchParams) => {
     const finalParams = { 
       ...searchParams, 
       page: page.value - 1, 
-      size: 12, // 페이지 사이즈 조정
+      size: 8, // 페이지 사이즈 조정 - 8개씩
       sort: sortByToParam(sortBy.value)
     };
     
@@ -332,7 +327,7 @@ const performSearch = async (searchParams) => {
     } else {
       const rdbParams = {
         page: page.value - 1,
-        size: 12,
+        size: 8,
         sortBy: sortBy.value === 'popularity' ? 'likeCount' : 'recent'
       };
       result = await getPortfolios(rdbParams);
@@ -398,6 +393,12 @@ const clearSearch = () => { searchQuery.value = ''; handleSearch(); };
 
 // 유틸리티
 const getActiveFilterCount = () => selectedTechParts.value.length + selectedTechStacks.value.length + selectedExperiences.value.length;
+
+const handlePageChange = (newPage) => {
+  if (newPage >= 1 && newPage <= totalPages.value) {
+    page.value = newPage;
+  }
+};
 
 const goToPage = (newPage) => {
   if (newPage >= 1 && newPage <= totalPages.value) {
@@ -469,9 +470,4 @@ const sortByToParam = (v) => {
 @keyframes spin { to { transform: rotate(360deg); } }
 .empty-icon { font-size: 64px; margin-bottom: 16px; opacity: 0.5; }
 .empty-message h3 { font-size: 20px; font-weight: 600; }
-.pagination-bar { margin-top: 24px; display: flex; justify-content: center; gap: 8px; }
-.pagination-bar button { background: #fff; border: 1px solid #D1D5DB; border-radius: 8px; padding: 8px 16px; cursor: pointer; transition: all 0.2s; font-weight: 500; }
-.pagination-bar button:hover { background: #F1F8E9; border-color: #C8E6C9; color: #2E7D32; }
-.pagination-bar button.active { background: #4CAF50; color: #fff; border-color: #4CAF50; }
-.pagination-bar button:disabled { opacity: 0.5; cursor: default; background: #F3F4F6; }
 </style>

--- a/src/views/ProjectListPage.vue
+++ b/src/views/ProjectListPage.vue
@@ -146,18 +146,12 @@
             </div>
           </div>
 
-          <div class="pagination-bar">
-            <button @click="goToPage(page - 1)" :disabled="page === 1">이전</button>
-            <button
-                v-for="p in totalPages"
-                :key="p"
-                :class="{ active: page === p }"
-                @click="goToPage(p)"
-            >
-              {{ p }}
-            </button>
-            <button @click="goToPage(page + 1)" :disabled="page === totalPages">다음</button>
-          </div>
+          <PaginationComponent 
+            :current-page="page" 
+            :total-pages="totalPages" 
+            :page-group-size="5" 
+            @page-change="handlePageChange" 
+          />
         </div>
       </div>
     </div>
@@ -193,6 +187,7 @@ import PageHeader from '@/components/common/PageHeader.vue';
 import SortOptions from '@/components/projectComponents/SortOptions.vue';
 import ProjectCard from '@/components/projectComponents/ProjectCard.vue';
 import ApplyModal from '@/components/projectComponents/ApplyModal.vue';
+import PaginationComponent from '@/components/common/PaginationComponent.vue';
 // import PaginationComponent from '@/components/projectComponents/PaginationComponent.vue'; // This component is not used in the template
 
 import { applyProject } from '@/api/projectMember';
@@ -351,7 +346,7 @@ const performSearch = async (searchParams) => {
     const finalParams = {
       ...searchParams,
       page: page.value - 1,
-      size: 8,
+      size: 5,
       sort: sort.value,
     };
     
@@ -379,7 +374,7 @@ const performSearch = async (searchParams) => {
       
       if (sort.value === 'likeCount,desc') {
         // 좋아요순 정렬
-        const url = `/projects?page=${page.value - 1}&size=8&sort=likeCount,desc`;
+        const url = `/projects?page=${page.value - 1}&size=5&sort=likeCount,desc`;
         console.log('🔧 Popular sort URL:', url);
         result = await api.get(url);
         console.log('📊 Popular sort response - first 3 projects:', result.data?.content?.slice(0, 3).map(p => ({id: p.projectId, likeCount: p.likeCount})));
@@ -387,7 +382,7 @@ const performSearch = async (searchParams) => {
         // 최신순이나 기본값
         const rdbParams = {
           page: page.value - 1,
-          size: 8,
+          size: 5,
           sort: sort.value
         };
         console.log('🔧 RDB params for latest sort:', rdbParams);
@@ -433,6 +428,12 @@ const handleSortChange = (newSort) => {
 const goToPage = (p) => {
   if (p >= 1 && p <= totalPages.value) {
     page.value = p;
+  }
+};
+
+const handlePageChange = (newPage) => {
+  if (newPage >= 1 && newPage <= totalPages.value) {
+    page.value = newPage;
   }
 };
 
@@ -843,33 +844,6 @@ const handleLikeUpdate = ({ projectId, liked, likeCount }) => {
 .empty-icon { font-size: 64px; margin-bottom: 16px; opacity: 0.5; }
 .empty-message h3 { font-size: 20px; font-weight: 600; }
 
-/* 페이지네이션 */
-.pagination-bar {
-  margin-top: 24px;
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-}
-.pagination-bar button {
-  background: #fff;
-  border: 1px solid #D1D5DB;
-  border-radius: 8px;
-  padding: 8px 16px;
-  cursor: pointer;
-  transition: all 0.2s;
-  font-weight: 500;
-}
-.pagination-bar button:hover {
-  background: #F1F8E9;
-  border-color: #C8E6C9;
-  color: #2E7D32;
-}
-.pagination-bar button.active {
-  background: #4CAF50;
-  color: #fff;
-  border-color: #4CAF50;
-}
-.pagination-bar button:disabled { opacity: 0.5; cursor: default; background: #F3F4F6; }
 
 /* 토스트 */
 .success-toast, .fail-toast { position: fixed; top: 80px; right: 30px; color: white; padding: 16px 24px; border-radius: 12px; z-index: 1001; animation: slideInRight 0.3s ease; box-shadow: 0 8px 25px rgba(0,0,0,0.15); }


### PR DESCRIPTION
- 컴포넌트 분리 : 프로필 이미지 , 페이지네이션


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 공통 페이지네이션 도입 및 적용: 프로젝트 섹션, 리뷰 섹션, 포트폴리오/프로젝트 목록에 그룹 이동·이전/다음·현재 페이지 표시 지원.
  * 프로필 이미지 컴포넌트 도입: 즐겨찾기/내 포트폴리오/추천 탭 등에서 일관된 아바타, 자동 폴백(디스베어/이니셜/기본), 사이즈·원형 지원.
  * 페이지 크기 조정: 포트폴리오 목록 8개/페이지, 프로젝트 목록 5개/페이지.
* Refactor
  * 프로젝트 선택 모달·내 프로젝트 목록의 데이터 로딩 경로 통합 및 표시 형식 개선, 오류 처리 단순화.
* Documentation
  * ProfileImage 사용법과 폴백 전략 문서 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->