### PR TITLE
fix: 정렬 기능 수정

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -29,7 +29,7 @@ export const searchProjects = async (params = {}) => {
     queryParams.append('page', params.page || 0)
     queryParams.append('size', params.size || 20)
     
-            if (params.sort) queryParams.append('sort', params.sort)
+            if (params.sort) queryParams.append('sortBy', params.sort)
     
     const response = await api.get(`/search/projects?${queryParams.toString()}`)
     return response.data
@@ -69,6 +69,8 @@ export const searchUsers = async (params = {}) => {
     
     queryParams.append('page', params.page || 0)
     queryParams.append('size', params.size || 20)
+    
+    if (params.sort) queryParams.append('sortBy', params.sort)
     
     const response = await api.get(`/search/users?${queryParams.toString()}`)
     return response.data

--- a/src/views/PortfolioListPage.vue
+++ b/src/views/PortfolioListPage.vue
@@ -308,33 +308,38 @@ const performSearch = async (searchParams) => {
   loading.value = true;
   error.value = null;
   try {
+    // 검색/필터 조건이 있을 때는 전체 데이터를 가져와서 프론트엔드에서 정렬 및 페이지네이션
+    const hasSearchConditions = 
+      searchParams.keyword || 
+      (searchParams.techParts && searchParams.techParts.length > 0) || 
+      (searchParams.techStacks && searchParams.techStacks.length > 0) || 
+      (searchParams.experienceRanges && searchParams.experienceRanges.length > 0);
+
     const finalParams = { 
       ...searchParams, 
-      page: page.value - 1, 
-      size: 8, // 페이지 사이즈 조정 - 8개씩
-      sort: sortByToParam(sortBy.value)
+      page: hasSearchConditions ? 0 : page.value - 1, 
+      size: hasSearchConditions ? 1000 : 8, // 검색 시 대량 데이터 가져오기
+      sort: convertSortToBackend(sortBy.value)
     };
-    
-    const hasSearchConditions = 
-      finalParams.keyword || 
-      (finalParams.techParts && finalParams.techParts.length > 0) || 
-      (finalParams.techStacks && finalParams.techStacks.length > 0) || 
-      (finalParams.experienceRanges && finalParams.experienceRanges.length > 0);
     
     let result;
     if (hasSearchConditions) {
+      // 검색/필터 조건이 있으면 Elasticsearch 사용 (정렬 옵션 포함)
       result = await searchUsers(finalParams);
     } else {
+      // 검색/필터 조건이 없으면 RDB에서 가져오기 (최신순/인기순/생성일순)
+      console.log('🗄️ Using RDB API for portfolios...');
       const rdbParams = {
         page: page.value - 1,
         size: 8,
-        sortBy: sortBy.value === 'popularity' ? 'likeCount' : 'recent'
+        sortBy: getSortByParam(sortBy.value)
       };
+      console.log('🔧 RDB params for portfolios:', rdbParams);
       result = await getPortfolios(rdbParams);
     }
     
     const data = result.data || result;
-    portfolios.value = (data.content || data.portfolios)?.map(user => ({
+    let portfolioList = (data.content || data.portfolios)?.map(user => ({
       userId: user.userId,
       id: user.userId,
       name: user.nickname || `User ${user.userId}`,
@@ -348,8 +353,35 @@ const performSearch = async (searchParams) => {
       bio: user.bio || '',
     })) || [];
     
-    totalPages.value = data.totalPages || 1;
-    totalPortfolios.value = data.totalElements || 0;
+    if (hasSearchConditions) {
+      // 검색/필터 조건이 있을 때: 전체 데이터 정렬 후 페이지네이션
+      // 1. 프론트엔드에서 정렬
+      if (sortBy.value === 'popularity') {
+        portfolioList = portfolioList.sort((a, b) => (b.likeCount || 0) - (a.likeCount || 0));
+      } else if (sortBy.value === 'recent') {
+        portfolioList = portfolioList.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      }
+      
+      // 2. 페이지네이션 적용
+      const pageSize = 8;
+      const startIndex = (page.value - 1) * pageSize;
+      const endIndex = startIndex + pageSize;
+      const totalElements = portfolioList.length;
+      
+      portfolios.value = portfolioList.slice(startIndex, endIndex);
+      totalPages.value = Math.ceil(totalElements / pageSize);
+      totalPortfolios.value = totalElements;
+      
+    } else {
+      // 검색/필터 조건이 없을 때: 기존 방식 (백엔드 페이지네이션)
+      if (sortBy.value === 'popularity') {
+        portfolioList = portfolioList.sort((a, b) => (b.likeCount || 0) - (a.likeCount || 0));
+      }
+      
+      portfolios.value = portfolioList;
+      totalPages.value = data.totalPages || 1;
+      totalPortfolios.value = data.totalElements || 0;
+    }
 
   } catch (err) {
     console.error('검색 실패:', err);
@@ -408,7 +440,44 @@ const goToPage = (newPage) => {
 
 const setSortBy = (sortType) => {
   sortBy.value = sortType;
-  handleSearch();
+  // 페이지를 1로 리셋
+  page.value = 1;
+  
+  // 현재 UI 상태에서 검색 파라미터를 직접 구성
+  const searchParams = {
+    keyword: searchQuery.value.trim() || null,
+    techParts: selectedTechParts.value.length > 0 ? selectedTechParts.value : null,
+    techStacks: selectedTechStacks.value.length > 0 ? selectedTechStacks.value : null,
+    experienceRanges: selectedExperiences.value.length > 0 ? selectedExperiences.value : null
+  };
+  
+  // currentSearchParams도 업데이트
+  currentSearchParams.value = searchParams;
+  isSearchMode.value = Object.values(searchParams).some(v => v !== null && v !== undefined && v.length !== 0);
+  
+  performSearch(searchParams);
+};
+
+const getSortByParam = (sortType) => {
+  switch (sortType) {
+    case 'popularity': return 'likeCount';
+    case 'created': return 'createdAt'; 
+    case 'recent':
+    default: return 'recent';
+  }
+};
+
+// 프론트엔드 정렬 값을 백엔드 형식으로 변환
+const convertSortToBackend = (sortValue) => {
+  switch (sortValue) {
+    case 'recent':
+      return 'latest';
+    case 'popularity':
+      // 백엔드 popularity 정렬이 작동하지 않으므로 latest 사용 후 프론트에서 정렬
+      return 'latest';
+    default:
+      return 'latest';
+  }
 };
 
 const sortByToParam = (v) => {

--- a/src/views/ProjectListPage.vue
+++ b/src/views/ProjectListPage.vue
@@ -343,32 +343,26 @@ const performSearch = async (searchParams) => {
   loading.value = true;
   error.value = null;
   try {
+    // 검색/필터 조건이 있을 때는 전체 데이터를 가져와서 프론트엔드에서 정렬 및 페이지네이션
+    const hasSearchConditions = 
+      searchParams.keyword || 
+      (searchParams.techParts && searchParams.techParts.length > 0) || 
+      (searchParams.techStacks && searchParams.techStacks.length > 0) || 
+      (searchParams.statuses && searchParams.statuses.length > 0);
+
     const finalParams = {
       ...searchParams,
-      page: page.value - 1,
-      size: 5,
-      sort: sort.value,
+      page: hasSearchConditions ? 0 : page.value - 1,
+      size: hasSearchConditions ? 1000 : 5, // 검색 시 대량 데이터 가져오기
+      sort: convertSortToBackend(sort.value),
     };
-    
-    // 검색 조건이 있는지 확인 (키워드, 기술 파트, 기술 스택, 상태 필터)
-    const hasSearchConditions = 
-      finalParams.keyword || 
-      (finalParams.techParts && finalParams.techParts.length > 0) || 
-      (finalParams.techStacks && finalParams.techStacks.length > 0) || 
-      (finalParams.statuses && finalParams.statuses.length > 0);
-    
-    console.log('🔍 Search conditions check:', {
-      hasSearchConditions,
-      finalParams
-    });
     
     let result;
     if (hasSearchConditions) {
-      // 검색/필터 조건이 있으면 Elasticsearch 사용
-      console.log('📊 Using Elasticsearch API...');
+      // 검색/필터 조건이 있으면 Elasticsearch 사용 (정렬 옵션 포함)
       result = await searchProjects(finalParams);
     } else {
-      // 검색/필터 조건이 없으면 RDB에서 가져오기 (최신순/인기순)
+      // 검색/필터 조건이 없으면 RDB에서 가져오기 (최신순/인기순/마감순)
       console.log('🗄️ Using RDB API...');
       console.log('🔍 Current sort.value:', sort.value, typeof sort.value);
       
@@ -378,6 +372,12 @@ const performSearch = async (searchParams) => {
         console.log('🔧 Popular sort URL:', url);
         result = await api.get(url);
         console.log('📊 Popular sort response - first 3 projects:', result.data?.content?.slice(0, 3).map(p => ({id: p.projectId, likeCount: p.likeCount})));
+      } else if (sort.value === 'recruitDeadline,asc') {
+        // 마감순 정렬
+        const url = `/projects?page=${page.value - 1}&size=5&sort=recruitDeadline,asc`;
+        console.log('🔧 Deadline sort URL:', url);
+        result = await api.get(url);
+        console.log('📊 Deadline sort response - first 3 projects:', result.data?.content?.slice(0, 3).map(p => ({id: p.projectId, deadline: p.recruitDeadline})));
       } else {
         // 최신순이나 기본값
         const rdbParams = {
@@ -388,15 +388,51 @@ const performSearch = async (searchParams) => {
         console.log('🔧 RDB params for latest sort:', rdbParams);
         result = await listProjects(rdbParams);
       }
-      console.log('✅ RDB API response:', result);
-      console.log('📊 Projects with likeCount:', result.data?.content?.map(p => ({id: p.projectId, title: p.title.substring(0,20), likeCount: p.likeCount})));
     }
     
     // axios 응답 구조에 맞게 데이터 추출
     const data = result.data || result;
-    projects.value = data.content || [];
-    totalPages.value = data.totalPages || 1;
-    console.log('📋 Final projects:', projects.value.length, 'projects loaded');
+    let projectList = data.content || [];
+    
+    if (hasSearchConditions) {
+      // 검색/필터 조건이 있을 때: 전체 데이터 정렬 후 페이지네이션
+      // 1. 프론트엔드에서 정렬
+      if (sort.value === 'likeCount,desc') {
+        projectList = projectList.sort((a, b) => (b.likeCount || 0) - (a.likeCount || 0));
+      } else if (sort.value === 'recruitDeadline,asc') {
+        projectList = projectList.sort((a, b) => {
+          const dateA = a.recruitDeadline ? new Date(a.recruitDeadline) : new Date('9999-12-31');
+          const dateB = b.recruitDeadline ? new Date(b.recruitDeadline) : new Date('9999-12-31');
+          return dateA - dateB;
+        });
+      } else if (sort.value === 'createdAt,desc') {
+        projectList = projectList.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      }
+      
+      // 2. 페이지네이션 적용
+      const pageSize = 5;
+      const startIndex = (page.value - 1) * pageSize;
+      const endIndex = startIndex + pageSize;
+      const totalElements = projectList.length;
+      
+      projects.value = projectList.slice(startIndex, endIndex);
+      totalPages.value = Math.ceil(totalElements / pageSize);
+      
+    } else {
+      // 검색/필터 조건이 없을 때: 기존 방식 (백엔드 페이지네이션)
+      if (sort.value === 'likeCount,desc') {
+        projectList = projectList.sort((a, b) => (b.likeCount || 0) - (a.likeCount || 0));
+      } else if (sort.value === 'recruitDeadline,asc') {
+        projectList = projectList.sort((a, b) => {
+          const dateA = a.recruitDeadline ? new Date(a.recruitDeadline) : new Date('9999-12-31');
+          const dateB = b.recruitDeadline ? new Date(b.recruitDeadline) : new Date('9999-12-31');
+          return dateA - dateB;
+        });
+      }
+      
+      projects.value = projectList;
+      totalPages.value = data.totalPages || 1;
+    }
   } catch (err) {
     console.error('❌ 프로젝트 로드 실패:', err);
     console.error('❌ 에러 상세:', {
@@ -422,7 +458,22 @@ const selectPopularKeyword = (keyword) => {
 
 const handleSortChange = (newSort) => {
   sort.value = newSort;
-  handleSearch();
+  // 페이지를 1로 리셋
+  page.value = 1;
+  
+  // 현재 UI 상태에서 검색 파라미터를 직접 구성
+  const searchParams = {
+    keyword: searchQuery.value.trim() || null,
+    techParts: selectedTechParts.value.length > 0 ? selectedTechParts.value : null,
+    techStacks: selectedTechStacks.value.length > 0 ? selectedTechStacks.value : null,
+    statuses: selectedStatuses.value.length > 0 ? selectedStatuses.value : null
+  };
+  
+  // currentSearchParams도 업데이트
+  currentSearchParams.value = searchParams;
+  isSearchMode.value = Object.values(searchParams).some(v => v !== null && v !== undefined && v.length !== 0);
+  
+  performSearch(searchParams);
 };
 
 const goToPage = (p) => {
@@ -564,6 +615,21 @@ const handleApplicationSubmitted = async (applicationData) => {
     setTimeout(() => (showFailToast.value = false), 3000);
   } finally {
     closeApplyModal();
+  }
+};
+
+// 프론트엔드 정렬 값을 백엔드 형식으로 변환
+const convertSortToBackend = (sortValue) => {
+  switch (sortValue) {
+    case 'createdAt,desc':
+      return 'latest';
+    case 'likeCount,desc':
+      // 백엔드 popularity 정렬이 작동하지 않으므로 latest 사용 후 프론트에서 정렬
+      return 'latest';
+    case 'recruitDeadline,asc':
+      return 'deadline';
+    default:
+      return 'latest';
   }
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 검색/필터 사용 시 클라이언트 측 정렬·페이지네이션 도입: 포트폴리오 8개/페이지, 프로젝트 5개/페이지로 표시.
  * 정렬 옵션을 일관 적용(인기, 최신, 마감 임박 등)하여 검색 결과에서도 동일한 기준으로 정렬.
  * 검색 결과 카드 정보 확장(직무, 카테고리, 스킬, 아바타, 좋아요, 경력 구간, 소개 등)으로 가독성 향상.
  * 정렬 변경 시 자동으로 1페이지로 이동.
  * 필터 상태 저장/복원 지원 및 초기 로딩 개선(태그·인기 키워드 로드).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->